### PR TITLE
Moving variable calculations to Common Classifier

### DIFF
--- a/BoostedAnalyzer/interface/essentialMVAVarProcessor.hpp
+++ b/BoostedAnalyzer/interface/essentialMVAVarProcessor.hpp
@@ -21,6 +21,7 @@ public:
 
 private:
   std::map<std::string, float> varMap;
+  std::string btagger;
   //MVAvars from CommonClassifier classifier for sl channel
   std::unique_ptr<MVAvars> pointerToMVAvars = nullptr;
 };

--- a/BoostedAnalyzer/interface/essentialRecoVarProcessor.hpp
+++ b/BoostedAnalyzer/interface/essentialRecoVarProcessor.hpp
@@ -1,0 +1,29 @@
+#ifndef BOOSTEDTTH_BOOSTEDANALYZER_ESSENTIALRECOVARPROCESSOR_HPP
+#define BOOSTEDTTH_BOOSTEDANALYZER_ESSENTIALRECOVARPROCESSOR_HPP
+
+#include "BoostedTTH/BoostedAnalyzer/interface/TreeProcessor.hpp"
+#include "BoostedTTH/BoostedAnalyzer/interface/BoostedUtils.hpp"
+
+#include "MiniAOD/MiniAODHelper/interface/CSVHelper.h"
+
+#include "TTH/CommonClassifier/interface/ReconstructedVars.h"
+
+class essentialRecoVarProcessor : public TreeProcessor
+{
+
+public:
+    essentialRecoVarProcessor();
+
+    ~essentialRecoVarProcessor();
+
+    void Init(const InputCollections &input, VariableContainer &var);
+    void Process(const InputCollections &input, VariableContainer &var);
+
+private:
+    std::map<std::string, double> varMap;
+    std::string btagger;
+    // RecoVars from CommonClassifier classifier for sl channel
+    std::unique_ptr<ReconstructedVars> pointerToRecoVars = nullptr;
+};
+
+#endif

--- a/BoostedAnalyzer/plugins/BoostedAnalyzer.cc
+++ b/BoostedAnalyzer/plugins/BoostedAnalyzer.cc
@@ -93,6 +93,7 @@
 #include "BoostedTTH/BoostedAnalyzer/interface/BDTVarProcessor.hpp"
 #include "BoostedTTH/BoostedAnalyzer/interface/DNNVarProcessor.hpp"
 #include "BoostedTTH/BoostedAnalyzer/interface/essentialMVAVarProcessor.hpp"
+#include "BoostedTTH/BoostedAnalyzer/interface/essentialRecoVarProcessor.hpp"
 #include "BoostedTTH/BoostedAnalyzer/interface/essentialMCMatchVarProcessor.hpp"
 #include "BoostedTTH/BoostedAnalyzer/interface/BoostedJetVarProcessor.hpp"
 #include "BoostedTTH/BoostedAnalyzer/interface/BoostedAk4VarProcessor.hpp"
@@ -471,6 +472,9 @@ BoostedAnalyzer::BoostedAnalyzer(const edm::ParameterSet& iConfig):
         }
         if(std::find(processorNames.begin(),processorNames.end(),"essentialBasicVarProcessor")!=processorNames.end()) {
             treewriter->AddTreeProcessor(new essentialBasicVarProcessor(),"essentialBasicVarProcessor");
+        }
+        if(std::find(processorNames.begin(),processorNames.end(),"essentialRecoVarProcessor")!=processorNames.end()) {
+            treewriter->AddTreeProcessor(new essentialRecoVarProcessor(),"essentialRecoVarProcessor");
         }
        
     if(std::find(processorNames.begin(),processorNames.end(),"essentialMVAVarProcessor")!=processorNames.end()) {

--- a/BoostedAnalyzer/src/essentialBasicVarProcessor.cpp
+++ b/BoostedAnalyzer/src/essentialBasicVarProcessor.cpp
@@ -7,513 +7,562 @@ essentialBasicVarProcessor::~essentialBasicVarProcessor(){}
 
 
 void essentialBasicVarProcessor::Init(const InputCollections& input,VariableContainer& vars){
-  
-  // load dataEra 
-  era = input.era;
-  
-  vars.InitVar("Evt_ID","L");
-  vars.InitVar("Evt_Odd","I");
-  vars.InitVar("Evt_Run","I");
-  vars.InitVar("Evt_Lumi","I");
+    
+    // load dataEra 
+    era = input.era;
+    
+    vars.InitVar("Evt_ID","L");
+    vars.InitVar("Evt_Odd","I");
+    vars.InitVar("Evt_Run","I");
+    vars.InitVar("Evt_Lumi","I");
 
-  
-  
-  vars.InitVar( "N_Jets","I" );
-  vars.InitVar( "N_LooseJets","I" );
-  vars.InitVar( "N_TightLeptons","I" );
-  vars.InitVar( "N_LooseLeptons" ,"I");
-  vars.InitVar( "N_TightElectrons" ,"I");
-  vars.InitVar( "N_LooseElectrons","I" );
-  vars.InitVar( "N_TightMuons" ,"I");
-  vars.InitVar( "N_LooseMuons" ,"I");
-  vars.InitVar( "N_BTagsL" ,"I");
-  vars.InitVar( "N_BTagsM" ,"I");
-  vars.InitVar( "N_BTagsT","I" );
-  vars.InitVar( "N_PrimaryVertices","I" );
-  vars.InitVar( "N_GenPVs", "I");
-
-
-  
-  vars.InitVars( "LooseJet_E","N_LooseJets" );
-  vars.InitVars( "LooseJet_M","N_LooseJets" );
-  vars.InitVars( "LooseJet_Pt","N_LooseJets" );
-  vars.InitVars( "LooseJet_Phi","N_LooseJets" );
-  vars.InitVars( "LooseJet_Eta","N_LooseJets" );
-  vars.InitVars( "LooseJet_CSV","N_LooseJets" );
-  vars.InitVars( "LooseJet_Flav","N_LooseJets" );
-  vars.InitVars( "LooseJet_PartonFlav","N_LooseJets" );
-  vars.InitVars( "LooseJet_Charge","N_LooseJets" );
-  vars.InitVars( "LooseJet_PileUpID","N_LooseJets" );
-  vars.InitVars( "LooseJet_PileUpMVA","N_LooseJets" );
-
-  vars.InitVars( "LooseJet_GenJet_Pt","N_LooseJets" );
-  vars.InitVars( "LooseJet_GenJet_Eta","N_LooseJets" );
-  
-  vars.InitVars( "LooseJet_DeepCSV_b","N_LooseJets");
-  vars.InitVars( "LooseJet_DeepCSV_bb","N_LooseJets");
-  vars.InitVars( "LooseJet_DeepCSV_c","N_LooseJets");
-  vars.InitVars( "LooseJet_DeepCSV_udsg","N_LooseJets");
-
-  vars.InitVars( "LooseJet_DeepJetCSV","N_LooseJets");  
-  vars.InitVars( "LooseJet_DeepJet_b","N_LooseJets");
-  vars.InitVars( "LooseJet_DeepJet_bb","N_LooseJets");
-  vars.InitVars( "LooseJet_DeepJet_lepb","N_LooseJets");
-  vars.InitVars( "LooseJet_DeepJet_c","N_LooseJets");
-  vars.InitVars( "LooseJet_DeepJet_uds","N_LooseJets");
-  vars.InitVars( "LooseJet_DeepJet_g","N_LooseJets");
-  
-  vars.InitVars( "Jet_E","N_Jets" );
-  vars.InitVars( "Jet_M","N_Jets" );
-  vars.InitVars( "Jet_Pt","N_Jets" );
-  vars.InitVars( "Jet_Phi","N_Jets" );
-  vars.InitVars( "Jet_Eta","N_Jets" );
-  vars.InitVars( "Jet_CSV","N_Jets" );
-  vars.InitVars( "Jet_Flav","N_Jets" );
-  vars.InitVars( "Jet_PartonFlav","N_Jets" );
-  vars.InitVars( "Jet_Charge","N_Jets" );
-  vars.InitVars( "Jet_PileUpID","N_Jets" );
-  vars.InitVars( "Jet_PileUpMVA","N_Jets" );
-
-  vars.InitVars( "Jet_GenJet_Pt","N_Jets" );
-  vars.InitVars( "Jet_GenJet_Eta","N_Jets" );
-  
-  vars.InitVars( "Jet_DeepCSV_b","N_Jets");
-  vars.InitVars( "Jet_DeepCSV_bb","N_Jets");
-  vars.InitVars( "Jet_DeepCSV_c","N_Jets");
-  vars.InitVars( "Jet_DeepCSV_udsg","N_Jets");
-
-  vars.InitVars( "Jet_DeepJetCSV","N_Jets");  
-  vars.InitVars( "Jet_DeepJet_b","N_Jets");
-  vars.InitVars( "Jet_DeepJet_bb","N_Jets");
-  vars.InitVars( "Jet_DeepJet_lepb","N_Jets");
-  vars.InitVars( "Jet_DeepJet_c","N_Jets");
-  vars.InitVars( "Jet_DeepJet_uds","N_Jets");
-  vars.InitVars( "Jet_DeepJet_g","N_Jets");
-
-//   vars.InitVars( "TaggedJet_E","N_BTagsM" );
-//   vars.InitVars( "TaggedJet_M","N_BTagsM" );
-//   vars.InitVars( "TaggedJet_Pt","N_BTagsM" );
-//   vars.InitVars( "TaggedJet_Phi","N_BTagsM" );
-//   vars.InitVars( "TaggedJet_Eta","N_BTagsM" );
+    
+    
+    vars.InitVar( "N_Jets","I" );
+    vars.InitVar( "N_LooseJets","I" );
+    vars.InitVar( "N_TightLeptons","I" );
+    vars.InitVar( "N_LooseLeptons" ,"I");
+    vars.InitVar( "N_TightElectrons" ,"I");
+    vars.InitVar( "N_LooseElectrons","I" );
+    vars.InitVar( "N_TightMuons" ,"I");
+    vars.InitVar( "N_LooseMuons" ,"I");
+    vars.InitVar( "N_BTagsL" ,"I");
+    vars.InitVar( "N_BTagsM" ,"I");
+    vars.InitVar( "N_BTagsT","I" );
+    vars.InitVar( "N_PrimaryVertices","I" );
+    vars.InitVar( "N_GenPVs", "I");
 
 
-  
-  vars.InitVars( "LooseLepton_E","N_LooseLeptons" );
-  vars.InitVars( "LooseLepton_M","N_LooseLeptons" );
-  vars.InitVars( "LooseLepton_Pt","N_LooseLeptons" );
-  vars.InitVars( "LooseLepton_Eta","N_LooseLeptons" );
-  vars.InitVars( "LooseLepton_Phi","N_LooseLeptons" );
-  
-  vars.InitVars( "LooseMuon_E","N_LooseMuons" );
-  vars.InitVars( "LooseMuon_M","N_LooseMuons" );
-  vars.InitVars( "LooseMuon_Pt","N_LooseMuons" );
-  vars.InitVars( "LooseMuon_Eta","N_LooseMuons" );
-  vars.InitVars( "LooseMuon_Phi","N_LooseMuons" );
-  vars.InitVars( "LooseMuon_RelIso","N_LooseMuons" );
-  vars.InitVars( "LooseMuon_Charge","N_LooseMuons" );
-  vars.InitVars( "LooseMuon_Pt_BeForeRC","N_LooseMuons" );
-  vars.InitVars( "LooseMuon_roccorSF", "N_LooseMuons");
-  vars.InitVars( "LooseMuon_roccorSFUp", "N_LooseMuons");
-  vars.InitVars( "LooseMuon_roccorSFDown", "N_LooseMuons");
-  vars.InitVars( "LooseMuon_IdentificationSF","N_LooseMuons");
-  vars.InitVars( "LooseMuon_IdentificationSFUp","N_LooseMuons");
-  vars.InitVars( "LooseMuon_IdentificationSFDown","N_LooseMuons");
-  vars.InitVars( "LooseMuon_IsolationSF","N_LooseMuons");
-  vars.InitVars( "LooseMuon_IsolationSFUp","N_LooseMuons");
-  vars.InitVars( "LooseMuon_IsolationSFDown","N_LooseMuons");
+    
+    vars.InitVars( "LooseJet_E","N_LooseJets" );
+    vars.InitVars( "LooseJet_M","N_LooseJets" );
+    vars.InitVars( "LooseJet_Pt","N_LooseJets" );
+    vars.InitVars( "LooseJet_Phi","N_LooseJets" );
+    vars.InitVars( "LooseJet_Eta","N_LooseJets" );
+    vars.InitVars( "LooseJet_CSV","N_LooseJets" );
+    vars.InitVars( "LooseJet_Flav","N_LooseJets" );
+    vars.InitVars( "LooseJet_PartonFlav","N_LooseJets" );
+    vars.InitVars( "LooseJet_Charge","N_LooseJets" );
+    vars.InitVars( "LooseJet_PileUpID","N_LooseJets" );
+    vars.InitVars( "LooseJet_PileUpMVA","N_LooseJets" );
 
-  vars.InitVars( "Muon_E","N_TightMuons" );
-  vars.InitVars( "Muon_M","N_TightMuons" );
-  vars.InitVars( "Muon_Pt","N_TightMuons" );
-  vars.InitVars( "Muon_Eta","N_TightMuons" );
-  vars.InitVars( "Muon_Phi","N_TightMuons" );
-  vars.InitVars( "Muon_RelIso","N_TightMuons" );
-  vars.InitVars( "Muon_Charge","N_TightMuons" );
-  vars.InitVars( "Muon_Pt_BeForeRC","N_TightMuons" );
-  vars.InitVars( "Muon_roccorSF", "N_TightMuons");
-  vars.InitVars( "Muon_roccorSFUp", "N_TightMuons");
-  vars.InitVars( "Muon_roccorSFDown", "N_TightMuons");
-  vars.InitVars( "Muon_IdentificationSF","N_TightMuons");
-  vars.InitVars( "Muon_IdentificationSFUp","N_TightMuons");
-  vars.InitVars( "Muon_IdentificationSFDown","N_TightMuons");
-  vars.InitVars( "Muon_IsolationSF","N_TightMuons");
-  vars.InitVars( "Muon_IsolationSFUp","N_TightMuons");
-  vars.InitVars( "Muon_IsolationSFDown","N_TightMuons");
+    vars.InitVars( "LooseJet_GenJet_Pt","N_LooseJets" );
+    vars.InitVars( "LooseJet_GenJet_Eta","N_LooseJets" );
+    
+    vars.InitVars( "LooseJet_DeepCSV_b","N_LooseJets");
+    vars.InitVars( "LooseJet_DeepCSV_bb","N_LooseJets");
+    vars.InitVars( "LooseJet_DeepCSV_c","N_LooseJets");
+    vars.InitVars( "LooseJet_DeepCSV_udsg","N_LooseJets");
+
+    vars.InitVars( "LooseJet_DeepJetCSV","N_LooseJets");    
+    vars.InitVars( "LooseJet_DeepJet_b","N_LooseJets");
+    vars.InitVars( "LooseJet_DeepJet_bb","N_LooseJets");
+    vars.InitVars( "LooseJet_DeepJet_lepb","N_LooseJets");
+    vars.InitVars( "LooseJet_DeepJet_c","N_LooseJets");
+    vars.InitVars( "LooseJet_DeepJet_uds","N_LooseJets");
+    vars.InitVars( "LooseJet_DeepJet_g","N_LooseJets");
+    
+    vars.InitVars( "Jet_E","N_Jets" );
+    vars.InitVars( "Jet_M","N_Jets" );
+    vars.InitVars( "Jet_Pt","N_Jets" );
+    vars.InitVars( "Jet_Phi","N_Jets" );
+    vars.InitVars( "Jet_Eta","N_Jets" );
+    vars.InitVars( "Jet_CSV","N_Jets" );
+    vars.InitVars( "Jet_Flav","N_Jets" );
+    vars.InitVars( "Jet_PartonFlav","N_Jets" );
+    vars.InitVars( "Jet_Charge","N_Jets" );
+    vars.InitVars( "Jet_PileUpID","N_Jets" );
+    vars.InitVars( "Jet_PileUpMVA","N_Jets" );
+
+    vars.InitVars( "Jet_GenJet_Pt","N_Jets" );
+    vars.InitVars( "Jet_GenJet_Eta","N_Jets" );
+    
+    vars.InitVars( "Jet_DeepCSV_b","N_Jets");
+    vars.InitVars( "Jet_DeepCSV_bb","N_Jets");
+    vars.InitVars( "Jet_DeepCSV_c","N_Jets");
+    vars.InitVars( "Jet_DeepCSV_udsg","N_Jets");
+
+    vars.InitVars( "Jet_DeepJetCSV","N_Jets");    
+    vars.InitVars( "Jet_DeepJet_b","N_Jets");
+    vars.InitVars( "Jet_DeepJet_bb","N_Jets");
+    vars.InitVars( "Jet_DeepJet_lepb","N_Jets");
+    vars.InitVars( "Jet_DeepJet_c","N_Jets");
+    vars.InitVars( "Jet_DeepJet_uds","N_Jets");
+    vars.InitVars( "Jet_DeepJet_g","N_Jets");
+
+    vars.InitVars( "TaggedJet_E","N_BTagsM" );
+    vars.InitVars( "TaggedJet_M","N_BTagsM" );
+    vars.InitVars( "TaggedJet_Pt","N_BTagsM" );
+    vars.InitVars( "TaggedJet_Phi","N_BTagsM" );
+    vars.InitVars( "TaggedJet_Eta","N_BTagsM" );
+    vars.InitVars( "TaggedJet_CSV","N_BTagsM" );
+    vars.InitVars( "TaggedJet_DeepJetCSV","N_BTagsM" );
+    vars.InitVars( "TaggedJet_DeepJet_b","N_BTagsM" );
+    vars.InitVars( "TaggedJet_DeepJet_bb","N_BTagsM" );
+    vars.InitVars( "TaggedJet_DeepJet_lepb","N_BTagsM" );
+    vars.InitVars( "TaggedJet_DeepJet_c","N_BTagsM" );
+    vars.InitVars( "TaggedJet_DeepJet_uds","N_BTagsM" );
+    vars.InitVars( "TaggedJet_DeepJet_g","N_BTagsM" );
+
+    vars.InitVars( "TightLepton_E","N_TightLeptons" );    
+    vars.InitVars( "TightLepton_M","N_TightLeptons" );    
+    vars.InitVars( "TightLepton_Pt","N_TightLeptons" );    
+    vars.InitVars( "TightLepton_Eta","N_TightLeptons" );    
+    vars.InitVars( "TightLepton_Phi","N_TightLeptons" );    
+
+    vars.InitVars( "LooseLepton_E","N_LooseLeptons" );
+    vars.InitVars( "LooseLepton_M","N_LooseLeptons" );
+    vars.InitVars( "LooseLepton_Pt","N_LooseLeptons" );
+    vars.InitVars( "LooseLepton_Eta","N_LooseLeptons" );
+    vars.InitVars( "LooseLepton_Phi","N_LooseLeptons" );
+    
+    vars.InitVars( "LooseMuon_E","N_LooseMuons" );
+    vars.InitVars( "LooseMuon_M","N_LooseMuons" );
+    vars.InitVars( "LooseMuon_Pt","N_LooseMuons" );
+    vars.InitVars( "LooseMuon_Eta","N_LooseMuons" );
+    vars.InitVars( "LooseMuon_Phi","N_LooseMuons" );
+    vars.InitVars( "LooseMuon_RelIso","N_LooseMuons" );
+    vars.InitVars( "LooseMuon_Charge","N_LooseMuons" );
+    vars.InitVars( "LooseMuon_Pt_BeForeRC","N_LooseMuons" );
+    vars.InitVars( "LooseMuon_roccorSF", "N_LooseMuons");
+    vars.InitVars( "LooseMuon_roccorSFUp", "N_LooseMuons");
+    vars.InitVars( "LooseMuon_roccorSFDown", "N_LooseMuons");
+    vars.InitVars( "LooseMuon_IdentificationSF","N_LooseMuons");
+    vars.InitVars( "LooseMuon_IdentificationSFUp","N_LooseMuons");
+    vars.InitVars( "LooseMuon_IdentificationSFDown","N_LooseMuons");
+    vars.InitVars( "LooseMuon_IsolationSF","N_LooseMuons");
+    vars.InitVars( "LooseMuon_IsolationSFUp","N_LooseMuons");
+    vars.InitVars( "LooseMuon_IsolationSFDown","N_LooseMuons");
+
+    vars.InitVars( "Muon_E","N_TightMuons" );
+    vars.InitVars( "Muon_M","N_TightMuons" );
+    vars.InitVars( "Muon_Pt","N_TightMuons" );
+    vars.InitVars( "Muon_Eta","N_TightMuons" );
+    vars.InitVars( "Muon_Phi","N_TightMuons" );
+    vars.InitVars( "Muon_RelIso","N_TightMuons" );
+    vars.InitVars( "Muon_Charge","N_TightMuons" );
+    vars.InitVars( "Muon_Pt_BeForeRC","N_TightMuons" );
+    vars.InitVars( "Muon_roccorSF", "N_TightMuons");
+    vars.InitVars( "Muon_roccorSFUp", "N_TightMuons");
+    vars.InitVars( "Muon_roccorSFDown", "N_TightMuons");
+    vars.InitVars( "Muon_IdentificationSF","N_TightMuons");
+    vars.InitVars( "Muon_IdentificationSFUp","N_TightMuons");
+    vars.InitVars( "Muon_IdentificationSFDown","N_TightMuons");
+    vars.InitVars( "Muon_IsolationSF","N_TightMuons");
+    vars.InitVars( "Muon_IsolationSFUp","N_TightMuons");
+    vars.InitVars( "Muon_IsolationSFDown","N_TightMuons");
 
 
-  
-  vars.InitVars( "LooseElectron_E","N_LooseElectrons" );
-  vars.InitVars( "LooseElectron_M","N_LooseElectrons" );
-  vars.InitVars( "LooseElectron_Pt","N_LooseElectrons" );
-  vars.InitVars( "LooseElectron_Eta","N_LooseElectrons" );
-  vars.InitVars( "LooseElectron_Phi","N_LooseElectrons" );
-  vars.InitVars( "LooseElectron_RelIso","N_LooseElectrons" );
-  vars.InitVars( "LooseElectron_Charge","N_LooseElectrons" );
-  vars.InitVars( "LooseElectron_Pt_BeforeRun2Calibration","N_LooseElectrons" );
-  vars.InitVars( "LooseElectron_Eta_Supercluster","N_LooseElectrons" );
-  // electron energy scale combined up/down
-  vars.InitVars( "LooseElectron_CorrFactor_ScaleUp","N_LooseElectrons");
-  vars.InitVars( "LooseElectron_CorrFactor_ScaleDown","N_LooseElectrons");
-  // electron energy smearing combined up/down
-  vars.InitVars( "LooseElectron_CorrFactor_SigmaUp","N_LooseElectrons");
-  vars.InitVars( "LooseElectron_CorrFactor_SigmaDown","N_LooseElectrons");
-  vars.InitVars( "LooseElectron_IdentificationSF","N_LooseElectrons");
-  vars.InitVars( "LooseElectron_IdentificationSFUp","N_LooseElectrons");
-  vars.InitVars( "LooseElectron_IdentificationSFDown","N_LooseElectrons");
-  vars.InitVars( "LooseElectron_ReconstructionSF","N_LooseElectrons");
-  vars.InitVars( "LooseElectron_ReconstructionSFUp","N_LooseElectrons");
-  vars.InitVars( "LooseElectron_ReconstructionSFDown","N_LooseElectrons");
-  
-  vars.InitVars( "Electron_E","N_TightElectrons" );
-  vars.InitVars( "Electron_M","N_TightElectrons" );
-  vars.InitVars( "Electron_Pt","N_TightElectrons" );
-  vars.InitVars( "Electron_Eta","N_TightElectrons" );
-  vars.InitVars( "Electron_Phi","N_TightElectrons" );
-  vars.InitVars( "Electron_RelIso","N_TightElectrons" );
-  vars.InitVars( "Electron_Charge","N_TightElectrons" );
-  vars.InitVars( "Electron_Pt_BeforeRun2Calibration","N_TightElectrons" );
-  vars.InitVars( "Electron_Eta_Supercluster","N_TightElectrons" );
-  // electron energy scale combined up/down
-  vars.InitVars( "Electron_CorrFactor_ScaleUp","N_TightElectrons");
-  vars.InitVars( "Electron_CorrFactor_ScaleDown","N_TightElectrons");
-  // electron energy smearing combined up/down
-  vars.InitVars( "Electron_CorrFactor_SigmaUp","N_TightElectrons");
-  vars.InitVars( "Electron_CorrFactor_SigmaDown","N_TightElectrons");
-  vars.InitVars( "Electron_IdentificationSF","N_TightElectrons");
-  vars.InitVars( "Electron_IdentificationSFUp","N_TightElectrons");
-  vars.InitVars( "Electron_IdentificationSFDown","N_TightElectrons");
-  vars.InitVars( "Electron_ReconstructionSF","N_TightElectrons");
-  vars.InitVars( "Electron_ReconstructionSFUp","N_TightElectrons");
-  vars.InitVars( "Electron_ReconstructionSFDown","N_TightElectrons");
-  
-  
-  
-  vars.InitVar( "Evt_MET_Pt" );
-  vars.InitVar( "Evt_MET_Phi" );
-  vars.InitVar( "Gen_MET_Pt" );
-  vars.InitVar( "Gen_MET_Phi" );
-  
-  
-  vars.InitVars( "CSV","N_Jets" );
-  initialized=true;
+    
+    vars.InitVars( "LooseElectron_E","N_LooseElectrons" );
+    vars.InitVars( "LooseElectron_M","N_LooseElectrons" );
+    vars.InitVars( "LooseElectron_Pt","N_LooseElectrons" );
+    vars.InitVars( "LooseElectron_Eta","N_LooseElectrons" );
+    vars.InitVars( "LooseElectron_Phi","N_LooseElectrons" );
+    vars.InitVars( "LooseElectron_RelIso","N_LooseElectrons" );
+    vars.InitVars( "LooseElectron_Charge","N_LooseElectrons" );
+    vars.InitVars( "LooseElectron_Pt_BeforeRun2Calibration","N_LooseElectrons" );
+    vars.InitVars( "LooseElectron_Eta_Supercluster","N_LooseElectrons" );
+    // electron energy scale combined up/down
+    vars.InitVars( "LooseElectron_CorrFactor_ScaleUp","N_LooseElectrons");
+    vars.InitVars( "LooseElectron_CorrFactor_ScaleDown","N_LooseElectrons");
+    // electron energy smearing combined up/down
+    vars.InitVars( "LooseElectron_CorrFactor_SigmaUp","N_LooseElectrons");
+    vars.InitVars( "LooseElectron_CorrFactor_SigmaDown","N_LooseElectrons");
+    vars.InitVars( "LooseElectron_IdentificationSF","N_LooseElectrons");
+    vars.InitVars( "LooseElectron_IdentificationSFUp","N_LooseElectrons");
+    vars.InitVars( "LooseElectron_IdentificationSFDown","N_LooseElectrons");
+    vars.InitVars( "LooseElectron_ReconstructionSF","N_LooseElectrons");
+    vars.InitVars( "LooseElectron_ReconstructionSFUp","N_LooseElectrons");
+    vars.InitVars( "LooseElectron_ReconstructionSFDown","N_LooseElectrons");
+    
+    vars.InitVars( "Electron_E","N_TightElectrons" );
+    vars.InitVars( "Electron_M","N_TightElectrons" );
+    vars.InitVars( "Electron_Pt","N_TightElectrons" );
+    vars.InitVars( "Electron_Eta","N_TightElectrons" );
+    vars.InitVars( "Electron_Phi","N_TightElectrons" );
+    vars.InitVars( "Electron_RelIso","N_TightElectrons" );
+    vars.InitVars( "Electron_Charge","N_TightElectrons" );
+    vars.InitVars( "Electron_Pt_BeforeRun2Calibration","N_TightElectrons" );
+    vars.InitVars( "Electron_Eta_Supercluster","N_TightElectrons" );
+    // electron energy scale combined up/down
+    vars.InitVars( "Electron_CorrFactor_ScaleUp","N_TightElectrons");
+    vars.InitVars( "Electron_CorrFactor_ScaleDown","N_TightElectrons");
+    // electron energy smearing combined up/down
+    vars.InitVars( "Electron_CorrFactor_SigmaUp","N_TightElectrons");
+    vars.InitVars( "Electron_CorrFactor_SigmaDown","N_TightElectrons");
+    vars.InitVars( "Electron_IdentificationSF","N_TightElectrons");
+    vars.InitVars( "Electron_IdentificationSFUp","N_TightElectrons");
+    vars.InitVars( "Electron_IdentificationSFDown","N_TightElectrons");
+    vars.InitVars( "Electron_ReconstructionSF","N_TightElectrons");
+    vars.InitVars( "Electron_ReconstructionSFUp","N_TightElectrons");
+    vars.InitVars( "Electron_ReconstructionSFDown","N_TightElectrons");
+    
+    
+    
+    vars.InitVar( "Evt_MET_Pt" );
+    vars.InitVar( "Evt_MET_Phi" );
+    vars.InitVar( "Gen_MET_Pt" );
+    vars.InitVar( "Gen_MET_Phi" );
+    
+    
+    vars.InitVars( "CSV","N_Jets" );
+    initialized=true;
 }
 
 void essentialBasicVarProcessor::Process(const InputCollections& input,VariableContainer& vars){
-  if(!initialized) cerr << "tree processor not initialized" << endl;
+    if(!initialized) cerr << "tree processor not initialized" << endl;
 
-  //also write the event ID for splitting purposes
-  long evt_id = input.eventInfo.evt;
-  long run_id = input.eventInfo.run;
-  long lumi_section = input.eventInfo.lumiBlock;
+    //also write the event ID for splitting purposes
+    long evt_id = input.eventInfo.evt;
+    long run_id = input.eventInfo.run;
+    long lumi_section = input.eventInfo.lumiBlock;
 
-  vars.FillIntVar("Evt_ID",evt_id);
-  vars.FillIntVar("Evt_Odd",evt_id%2);
-  vars.FillIntVar("Evt_Run",run_id);
-  vars.FillIntVar("Evt_Lumi",lumi_section);
+    vars.FillIntVar("Evt_ID",evt_id);
+    vars.FillIntVar("Evt_Odd",evt_id%2);
+    vars.FillIntVar("Evt_Run",run_id);
+    vars.FillIntVar("Evt_Lumi",lumi_section);
 
 
-  
-  const char* btagger="DeepJet";
-  std::vector<pat::Jet> selectedTaggedJets;
-  std::vector<pat::Jet> selectedTaggedJetsT;
-  std::vector<pat::Jet> selectedTaggedJetsL;
-  std::vector<pat::Jet> selectedUntaggedJets;
-  for(std::vector<pat::Jet>::const_iterator itJet = input.selectedJets.begin(); itJet != input.selectedJets.end(); ++itJet){
-    if(CSVHelper::PassesCSV(*itJet, btagger, CSVHelper::CSVwp::Medium, era)){
-      selectedTaggedJets.push_back(*itJet);
-    }
-    else{
-      selectedUntaggedJets.push_back(*itJet);
-    }
-    if(CSVHelper::PassesCSV(*itJet, btagger, CSVHelper::CSVwp::Loose, era)){
-      selectedTaggedJetsL.push_back(*itJet);
-    }
-    if(CSVHelper::PassesCSV(*itJet, btagger, CSVHelper::CSVwp::Tight, era)){
-      selectedTaggedJetsT.push_back(*itJet);
-    }
-  }
-  
-  // Fill Multiplicity Variables
-  vars.FillVar( "N_GenPVs",input.eventInfo.numTruePV);
-  vars.FillVar( "N_PrimaryVertices",input.selectedPVs.size());  
-  vars.FillVar( "N_Jets",input.selectedJets.size());
-  vars.FillVar( "N_LooseJets",input.selectedJetsLoose.size());
-  vars.FillVar( "N_TightLeptons",input.selectedElectrons.size()+ input.selectedMuons.size());  
-  vars.FillVar( "N_LooseLeptons",input.selectedElectronsLoose.size()+ input.selectedMuonsLoose.size());  
-  vars.FillVar( "N_TightElectrons",input.selectedElectrons.size());  
-  vars.FillVar( "N_LooseElectrons",input.selectedElectronsLoose.size());  
-  vars.FillVar( "N_TightMuons",input.selectedMuons.size());  
-  vars.FillVar( "N_LooseMuons",input.selectedMuonsLoose.size());  
-  
-  // Fill Jet Variables
-  // All Jets
-  for(std::vector<pat::Jet>::const_iterator itJet = input.selectedJets.begin() ; itJet != input.selectedJets.end(); ++itJet){
-    int iJet = itJet - input.selectedJets.begin();
-    vars.FillVars( "Jet_E",iJet,itJet->energy() );
-    vars.FillVars( "Jet_M",iJet,itJet->mass() );
-    vars.FillVars( "Jet_Pt",iJet,itJet->pt() );
-    vars.FillVars( "Jet_Eta",iJet,itJet->eta() );
-    vars.FillVars( "Jet_Phi",iJet,itJet->phi() );
-    vars.FillVars( "Jet_CSV",iJet,CSVHelper::GetJetCSV(*itJet,btagger) );
-    vars.FillVars( "Jet_Flav",iJet,itJet->hadronFlavour() );
-    vars.FillVars( "Jet_PartonFlav",iJet,itJet->partonFlavour() );
-    vars.FillVars( "Jet_Charge",iJet,itJet->jetCharge() );
-    if(itJet->hasUserInt("pileupJetIdUpdated:fullId")) {
-        vars.FillVars( "Jet_PileUpID",iJet,itJet->userInt("pileupJetIdUpdated:fullId"));
-    }
-    if(itJet->hasUserFloat("pileupJetIdUpdated:fullDiscriminant")) {
-        vars.FillVars( "Jet_PileUpMVA",iJet,itJet->userFloat("pileupJetIdUpdated:fullDiscriminant"));
-    }
-    if(itJet->genJet()!=NULL){
-      vars.FillVars( "Jet_GenJet_Pt",iJet,itJet->genJet()->pt());
-      vars.FillVars( "Jet_GenJet_Eta",iJet,itJet->genJet()->eta());
-    }
-    else {
-      vars.FillVars( "Jet_GenJet_Pt",iJet,-9.0);
-      vars.FillVars( "Jet_GenJet_Eta",iJet,-9.0);
-    }
-
-    vars.FillVars( "Jet_DeepCSV_b",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probb"));
-    vars.FillVars( "Jet_DeepCSV_bb",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probbb"));
-    vars.FillVars( "Jet_DeepCSV_c",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probc"));
-    vars.FillVars( "Jet_DeepCSV_udsg",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probudsg"));
     
-    vars.FillVars( "Jet_DeepJetCSV",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"DeepJet"));
-    vars.FillVars( "Jet_DeepJet_b",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probb"));
-    vars.FillVars( "Jet_DeepJet_bb",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probbb"));
-    vars.FillVars( "Jet_DeepJet_lepb",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:problepb"));
-    vars.FillVars( "Jet_DeepJet_c",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probc"));
-    vars.FillVars( "Jet_DeepJet_uds",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probuds"));
-    vars.FillVars( "Jet_DeepJet_g",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probg"));
-  }
-  
-  for(std::vector<pat::Jet>::const_iterator itJet = input.selectedJetsLoose.begin() ; itJet != input.selectedJetsLoose.end(); ++itJet){
-    int iJet = itJet - input.selectedJetsLoose.begin();
-    vars.FillVars( "LooseJet_E",iJet,itJet->energy() );
-    vars.FillVars( "LooseJet_M",iJet,itJet->mass() );
-    vars.FillVars( "LooseJet_Pt",iJet,itJet->pt() );
-    vars.FillVars( "LooseJet_Eta",iJet,itJet->eta() );
-    vars.FillVars( "LooseJet_Phi",iJet,itJet->phi() );
-    vars.FillVars( "LooseJet_CSV",iJet,CSVHelper::GetJetCSV(*itJet,btagger) );
-    //vars.FillVars( "LooseJet_CSV_DNN",iJet,CSVHelper::GetJetCSV_DNN(*itJet,btagger) );
-    vars.FillVars( "LooseJet_Flav",iJet,itJet->hadronFlavour() );
-    vars.FillVars( "LooseJet_PartonFlav",iJet,itJet->partonFlavour() );
-    vars.FillVars( "LooseJet_Charge",iJet,itJet->jetCharge() );
-    if(itJet->hasUserInt("pileupJetIdUpdated:fullId")) {
-        vars.FillVars( "LooseJet_PileUpID",iJet,itJet->userInt("pileupJetIdUpdated:fullId"));
-    }
-    if(itJet->hasUserFloat("pileupJetIdUpdated:fullDiscriminant")) {
-        vars.FillVars( "LooseJet_PileUpMVA",iJet,itJet->userFloat("pileupJetIdUpdated:fullDiscriminant"));
-    }
-    if(itJet->genJet()!=NULL){
-      vars.FillVars( "LooseJet_GenJet_Pt",iJet,itJet->genJet()->pt());
-      vars.FillVars( "LooseJet_GenJet_Eta",iJet,itJet->genJet()->eta());
-    }
-    else {
-      vars.FillVars( "LooseJet_GenJet_Pt",iJet,-9.0);
-      vars.FillVars( "LooseJet_GenJet_Eta",iJet,-9.0);
-    }
+    const char* btagger="DeepJet";
+    std::vector<pat::Jet> selectedTaggedJets;
+    std::vector<pat::Jet> selectedTaggedJetsT;
+    std::vector<pat::Jet> selectedTaggedJetsL;
+    std::vector<pat::Jet> selectedUntaggedJets;
+    for(std::vector<pat::Jet>::const_iterator itJet = input.selectedJets.begin(); itJet != input.selectedJets.end(); ++itJet)
+    {
+        if(CSVHelper::PassesCSV(*itJet, btagger, CSVHelper::CSVwp::Medium, era))
+            selectedTaggedJets.push_back(*itJet);
+        else
+            selectedUntaggedJets.push_back(*itJet);
+        
 
-    vars.FillVars( "LooseJet_DeepCSV_b",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probb"));
-    vars.FillVars( "LooseJet_DeepCSV_bb",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probbb"));
-    vars.FillVars( "LooseJet_DeepCSV_c",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probc"));
-    vars.FillVars( "LooseJet_DeepCSV_udsg",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probudsg"));
+        if(CSVHelper::PassesCSV(*itJet, btagger, CSVHelper::CSVwp::Loose, era))
+            selectedTaggedJetsL.push_back(*itJet);
+        if(CSVHelper::PassesCSV(*itJet, btagger, CSVHelper::CSVwp::Tight, era))
+            selectedTaggedJetsT.push_back(*itJet);
+    }
     
-    vars.FillVars( "LooseJet_DeepJetCSV",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"DeepJet"));
-    vars.FillVars( "LooseJet_DeepJet_b",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probb"));
-    vars.FillVars( "LooseJet_DeepJet_bb",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probbb"));
-    vars.FillVars( "LooseJet_DeepJet_lepb",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:problepb"));
-    vars.FillVars( "LooseJet_DeepJet_c",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probc"));
-    vars.FillVars( "LooseJet_DeepJet_uds",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probuds"));
-    vars.FillVars( "LooseJet_DeepJet_g",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probg"));
-  }
+    // Fill Multiplicity Variables
+    vars.FillVar( "N_GenPVs",input.eventInfo.numTruePV);
+    vars.FillVar( "N_PrimaryVertices",input.selectedPVs.size());    
+    vars.FillVar( "N_Jets",input.selectedJets.size());
+    vars.FillVar( "N_LooseJets",input.selectedJetsLoose.size());
+    vars.FillVar( "N_TightLeptons",input.selectedElectrons.size()+ input.selectedMuons.size());    
+    vars.FillVar( "N_LooseLeptons",input.selectedElectronsLoose.size()+ input.selectedMuonsLoose.size());    
+    vars.FillVar( "N_TightElectrons",input.selectedElectrons.size());    
+    vars.FillVar( "N_LooseElectrons",input.selectedElectronsLoose.size());    
+    vars.FillVar( "N_TightMuons",input.selectedMuons.size());    
+    vars.FillVar( "N_LooseMuons",input.selectedMuonsLoose.size());    
+    
+    // Fill Jet Variables
+    // All Jets
+    for(std::vector<pat::Jet>::const_iterator itJet = input.selectedJets.begin() ; itJet != input.selectedJets.end(); ++itJet)
+    {
+        int iJet = itJet - input.selectedJets.begin();
+        vars.FillVars( "Jet_E",iJet,itJet->energy() );
+        vars.FillVars( "Jet_M",iJet,itJet->mass() );
+        vars.FillVars( "Jet_Pt",iJet,itJet->pt() );
+        vars.FillVars( "Jet_Eta",iJet,itJet->eta() );
+        vars.FillVars( "Jet_Phi",iJet,itJet->phi() );
+        vars.FillVars( "Jet_CSV",iJet,CSVHelper::GetJetCSV(*itJet,btagger) );
+        vars.FillVars( "Jet_Flav",iJet,itJet->hadronFlavour() );
+        vars.FillVars( "Jet_PartonFlav",iJet,itJet->partonFlavour() );
+        vars.FillVars( "Jet_Charge",iJet,itJet->jetCharge() );
+        if(itJet->hasUserInt("pileupJetIdUpdated:fullId")) 
+            vars.FillVars( "Jet_PileUpID",iJet,itJet->userInt("pileupJetIdUpdated:fullId"));
+        if(itJet->hasUserFloat("pileupJetIdUpdated:fullDiscriminant")) 
+            vars.FillVars( "Jet_PileUpMVA",iJet,itJet->userFloat("pileupJetIdUpdated:fullDiscriminant"));
 
-  
-  
-  // Tagged Jets
-//   for(std::vector<pat::Jet>::iterator itTaggedJet = selectedTaggedJets.begin() ; itTaggedJet != selectedTaggedJets.end(); ++itTaggedJet){
-//     int iTaggedJet = itTaggedJet - selectedTaggedJets.begin();
-//     vars.FillVars( "TaggedJet_E",iTaggedJet,itTaggedJet->energy() );
-//     vars.FillVars( "TaggedJet_M",iTaggedJet,itTaggedJet->mass() );
-//     vars.FillVars( "TaggedJet_Pt",iTaggedJet,itTaggedJet->pt() );
-//     vars.FillVars( "TaggedJet_Eta",iTaggedJet,itTaggedJet->eta() );
-//     vars.FillVars( "TaggedJet_Phi",iTaggedJet,itTaggedJet->phi() );
-//   }
-  
-  // Fill Lepton Variables
-  std::vector<math::XYZTLorentzVector> looseLeptonVecs = BoostedUtils::GetLepVecs(input.selectedElectronsLoose,input.selectedMuonsLoose);
-  for(std::vector<math::XYZTLorentzVector>::iterator itLep = looseLeptonVecs.begin() ; itLep != looseLeptonVecs.end(); ++itLep){
-    int iLep = itLep - looseLeptonVecs.begin();
-    vars.FillVars( "LooseLepton_E",iLep,itLep->E() );
-    vars.FillVars( "LooseLepton_M",iLep,itLep->M() );
-    vars.FillVars( "LooseLepton_Pt",iLep,itLep->Pt() );
-    vars.FillVars( "LooseLepton_Eta",iLep,itLep->Eta());
-    vars.FillVars( "LooseLepton_Phi",iLep,itLep->Phi() );
-  }
-   
-  for(std::vector<pat::Electron>::const_iterator itEle = input.selectedElectronsLoose.begin(); itEle != input.selectedElectronsLoose.end(); ++itEle){
-    int iEle = itEle - input.selectedElectronsLoose.begin();
-    vars.FillVars( "LooseElectron_E",iEle,itEle->energy() );
-    vars.FillVars( "LooseElectron_M",iEle,itEle->mass() );
-    vars.FillVars( "LooseElectron_Pt",iEle,itEle->pt() );
-    vars.FillVars( "LooseElectron_Eta",iEle,itEle->eta() );
-    vars.FillVars( "LooseElectron_Phi",iEle,itEle->phi() ); 
-    if(itEle->hasUserFloat("relIso")){
-	vars.FillVars( "LooseElectron_RelIso",iEle,itEle->userFloat("relIso") );
+        if(itJet->genJet()!=NULL)
+        {
+            vars.FillVars( "Jet_GenJet_Pt",iJet,itJet->genJet()->pt());
+            vars.FillVars( "Jet_GenJet_Eta",iJet,itJet->genJet()->eta());
+        }
+        else 
+        {
+            vars.FillVars( "Jet_GenJet_Pt",iJet,-9.0);
+            vars.FillVars( "Jet_GenJet_Eta",iJet,-9.0);
+        }
+
+        vars.FillVars( "Jet_DeepCSV_b",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probb"));
+        vars.FillVars( "Jet_DeepCSV_bb",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probbb"));
+        vars.FillVars( "Jet_DeepCSV_c",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probc"));
+        vars.FillVars( "Jet_DeepCSV_udsg",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probudsg"));
+        
+        vars.FillVars( "Jet_DeepJetCSV",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"DeepJet"));
+        vars.FillVars( "Jet_DeepJet_b",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probb"));
+        vars.FillVars( "Jet_DeepJet_bb",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probbb"));
+        vars.FillVars( "Jet_DeepJet_lepb",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:problepb"));
+        vars.FillVars( "Jet_DeepJet_c",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probc"));
+        vars.FillVars( "Jet_DeepJet_uds",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probuds"));
+        vars.FillVars( "Jet_DeepJet_g",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probg"));
     }
-    vars.FillVars( "LooseElectron_Charge",iEle,itEle->charge() ); 
-    if(itEle->hasUserFloat("ptBeforeRun2Calibration")){
-        vars.FillVars("LooseElectron_Pt_BeforeRun2Calibration",iEle,itEle->userFloat("ptBeforeRun2Calibration"));
-    }
-    vars.FillVars("LooseElectron_Eta_Supercluster",iEle,itEle->superCluster()->eta());
-    if(itEle->hasUserFloat("CorrFactor_ScaleUp")){
-        // electron energy scale combined up/down
-        vars.FillVars( "LooseElectron_CorrFactor_ScaleUp",iEle,itEle->userFloat("CorrFactor_ScaleUp"));
-        vars.FillVars( "LooseElectron_CorrFactor_ScaleDown",iEle,itEle->userFloat("CorrFactor_ScaleDown"));
-        // electron energy smearing combined up/down
-        vars.FillVars( "LooseElectron_CorrFactor_SigmaUp",iEle,itEle->userFloat("CorrFactor_SigmaUp"));
-        vars.FillVars( "LooseElectron_CorrFactor_SigmaDown",iEle,itEle->userFloat("CorrFactor_SigmaDown"));
-    }
-    if(itEle->hasUserFloat("IdentificationSF")){
-        vars.FillVars( "LooseElectron_IdentificationSF",iEle,itEle->userFloat("IdentificationSF"));
-        vars.FillVars( "LooseElectron_IdentificationSFUp",iEle,itEle->userFloat("IdentificationSFUp"));
-        vars.FillVars( "LooseElectron_IdentificationSFDown",iEle,itEle->userFloat("IdentificationSFDown"));
-        vars.FillVars( "LooseElectron_ReconstructionSF",iEle,itEle->userFloat("ReconstructionSF"));
-        vars.FillVars( "LooseElectron_ReconstructionSFUp",iEle,itEle->userFloat("ReconstructionSFUp"));
-        vars.FillVars( "LooseElectron_ReconstructionSFDown",iEle,itEle->userFloat("ReconstructionSFDown"));
-    }
-  }
-  for(std::vector<pat::Electron>::const_iterator itEle = input.selectedElectrons.begin(); itEle != input.selectedElectrons.end(); ++itEle){
-    int iEle = itEle - input.selectedElectrons.begin();
-    vars.FillVars( "Electron_E",iEle,itEle->energy() );
-    vars.FillVars( "Electron_M",iEle,itEle->mass() );
-    vars.FillVars( "Electron_Pt",iEle,itEle->pt() );
-    vars.FillVars( "Electron_Eta",iEle,itEle->eta() );
-    vars.FillVars( "Electron_Phi",iEle,itEle->phi() ); 
-    if(itEle->hasUserFloat("relIso")){
-	vars.FillVars( "Electron_RelIso",iEle,itEle->userFloat("relIso") );
-    }
-    vars.FillVars( "Electron_Charge",iEle,itEle->charge() ); 
-    if(itEle->hasUserFloat("ptBeforeRun2Calibration")){
-        vars.FillVars("Electron_Pt_BeforeRun2Calibration",iEle,itEle->userFloat("ptBeforeRun2Calibration"));
-    }
-    vars.FillVars("Electron_Eta_Supercluster",iEle,itEle->superCluster()->eta());
-    if(itEle->hasUserFloat("CorrFactor_ScaleUp")){
-        // electron energy scale combined up/down
-        vars.FillVars( "Electron_CorrFactor_ScaleUp",iEle,itEle->userFloat("CorrFactor_ScaleUp"));
-        vars.FillVars( "Electron_CorrFactor_ScaleDown",iEle,itEle->userFloat("CorrFactor_ScaleDown"));
-        // electron energy smearing combined up/down
-        vars.FillVars( "Electron_CorrFactor_SigmaUp",iEle,itEle->userFloat("CorrFactor_SigmaUp"));
-        vars.FillVars( "Electron_CorrFactor_SigmaDown",iEle,itEle->userFloat("CorrFactor_SigmaDown"));
-    }
-    if(itEle->hasUserFloat("IdentificationSF")){
-        vars.FillVars( "Electron_IdentificationSF",iEle,itEle->userFloat("IdentificationSF"));
-        vars.FillVars( "Electron_IdentificationSFUp",iEle,itEle->userFloat("IdentificationSFUp"));
-        vars.FillVars( "Electron_IdentificationSFDown",iEle,itEle->userFloat("IdentificationSFDown"));
-        vars.FillVars( "Electron_ReconstructionSF",iEle,itEle->userFloat("ReconstructionSF"));
-        vars.FillVars( "Electron_ReconstructionSFUp",iEle,itEle->userFloat("ReconstructionSFUp"));
-        vars.FillVars( "Electron_ReconstructionSFDown",iEle,itEle->userFloat("ReconstructionSFDown"));
-    }
-  }
-  
-  for(std::vector<pat::Muon>::const_iterator itMu = input.selectedMuonsLoose.begin(); itMu != input.selectedMuonsLoose.end(); ++itMu){
-    int iMu = itMu - input.selectedMuonsLoose.begin();
-    vars.FillVars( "LooseMuon_E",iMu,itMu->energy() );
-    vars.FillVars( "LooseMuon_M",iMu,itMu->mass() );
-    vars.FillVars( "LooseMuon_Pt",iMu,itMu->pt() );
-    vars.FillVars( "LooseMuon_Eta",iMu,itMu->eta() );
-    vars.FillVars( "LooseMuon_Phi",iMu,itMu->phi() );
-    if(itMu->hasUserFloat("relIso")){
-	vars.FillVars( "LooseMuon_RelIso",iMu,itMu->userFloat("relIso") );
-    }
-    vars.FillVars( "LooseMuon_Charge",iMu,itMu->charge() );
-    if(itMu->hasUserFloat("PtbeforeRC")){
-      vars.FillVars( "LooseMuon_Pt_BeForeRC",iMu,itMu->userFloat("PtbeforeRC") );
-    }
-    if(itMu->hasUserFloat("roccorSF")){
-      vars.FillVars( "LooseMuon_roccorSF",iMu,itMu->userFloat("roccorSF") );
-    }
-    if(itMu->hasUserFloat("roccorSFUp")){
-      vars.FillVars( "LooseMuon_roccorSFUp",iMu,itMu->userFloat("roccorSFUp") );
-    }
-    if(itMu->hasUserFloat("roccorSFDown")){
-      vars.FillVars( "LooseMuon_roccorSFDown",iMu,itMu->userFloat("roccorSFDown") );
+    
+    for(std::vector<pat::Jet>::const_iterator itJet = input.selectedJetsLoose.begin() ; itJet != input.selectedJetsLoose.end(); ++itJet)
+    {
+        int iJet = itJet - input.selectedJetsLoose.begin();
+        vars.FillVars( "LooseJet_E",iJet,itJet->energy() );
+        vars.FillVars( "LooseJet_M",iJet,itJet->mass() );
+        vars.FillVars( "LooseJet_Pt",iJet,itJet->pt() );
+        vars.FillVars( "LooseJet_Eta",iJet,itJet->eta() );
+        vars.FillVars( "LooseJet_Phi",iJet,itJet->phi() );
+        vars.FillVars( "LooseJet_CSV",iJet,CSVHelper::GetJetCSV(*itJet,btagger) );
+        //vars.FillVars( "LooseJet_CSV_DNN",iJet,CSVHelper::GetJetCSV_DNN(*itJet,btagger) );
+        vars.FillVars( "LooseJet_Flav",iJet,itJet->hadronFlavour() );
+        vars.FillVars( "LooseJet_PartonFlav",iJet,itJet->partonFlavour() );
+        vars.FillVars( "LooseJet_Charge",iJet,itJet->jetCharge() );
+        if(itJet->hasUserInt("pileupJetIdUpdated:fullId")) 
+            vars.FillVars( "LooseJet_PileUpID",iJet,itJet->userInt("pileupJetIdUpdated:fullId"));
+        if(itJet->hasUserFloat("pileupJetIdUpdated:fullDiscriminant")) 
+                vars.FillVars( "LooseJet_PileUpMVA",iJet,itJet->userFloat("pileupJetIdUpdated:fullDiscriminant"));
+
+        if(itJet->genJet()!=NULL)
+        {
+            vars.FillVars( "LooseJet_GenJet_Pt",iJet,itJet->genJet()->pt());
+            vars.FillVars( "LooseJet_GenJet_Eta",iJet,itJet->genJet()->eta());
+        }
+        else 
+        {
+            vars.FillVars( "LooseJet_GenJet_Pt",iJet,-9.0);
+            vars.FillVars( "LooseJet_GenJet_Eta",iJet,-9.0);
+        }
+
+        vars.FillVars( "LooseJet_DeepCSV_b",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probb"));
+        vars.FillVars( "LooseJet_DeepCSV_bb",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probbb"));
+        vars.FillVars( "LooseJet_DeepCSV_c",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probc"));
+        vars.FillVars( "LooseJet_DeepCSV_udsg",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probudsg"));
+        
+        vars.FillVars( "LooseJet_DeepJetCSV",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"DeepJet"));
+        vars.FillVars( "LooseJet_DeepJet_b",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probb"));
+        vars.FillVars( "LooseJet_DeepJet_bb",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probbb"));
+        vars.FillVars( "LooseJet_DeepJet_lepb",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:problepb"));
+        vars.FillVars( "LooseJet_DeepJet_c",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probc"));
+        vars.FillVars( "LooseJet_DeepJet_uds",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probuds"));
+        vars.FillVars( "LooseJet_DeepJet_g",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probg"));
     }
 
-    if(itMu->hasUserFloat("IdentificationSF")){
-        vars.FillVars( "LooseMuon_IdentificationSF",iMu,itMu->userFloat("IdentificationSF"));
-        vars.FillVars( "LooseMuon_IdentificationSFUp",iMu,itMu->userFloat("IdentificationSFUp"));
-        vars.FillVars( "LooseMuon_IdentificationSFDown",iMu,itMu->userFloat("IdentificationSFDown"));
-    }
-    if(itMu->hasUserFloat("IsolationSF")){
-        vars.FillVars( "LooseMuon_IsolationSF",iMu,itMu->userFloat("IsolationSF"));
-        vars.FillVars( "LooseMuon_IsolationSFUp",iMu,itMu->userFloat("IsolationSFUp"));
-        vars.FillVars( "LooseMuon_IsolationSFDown",iMu,itMu->userFloat("IsolationSFDown"));
-    }
-  }
-  for(std::vector<pat::Muon>::const_iterator itMu = input.selectedMuons.begin(); itMu != input.selectedMuons.end(); ++itMu){
-    int iMu = itMu - input.selectedMuons.begin();
-    vars.FillVars( "Muon_E",iMu,itMu->energy() );
-    vars.FillVars( "Muon_M",iMu,itMu->mass() );
-    vars.FillVars( "Muon_Pt",iMu,itMu->pt() );
-    vars.FillVars( "Muon_Eta",iMu,itMu->eta() );
-    vars.FillVars( "Muon_Phi",iMu,itMu->phi() );
-    if(itMu->hasUserFloat("relIso")){
-	vars.FillVars( "Muon_RelIso",iMu,itMu->userFloat("relIso") );
-    }
-    vars.FillVars( "Muon_Charge",iMu,itMu->charge() );
-    if(itMu->hasUserFloat("PtbeforeRC")){
-      vars.FillVars( "Muon_Pt_BeForeRC",iMu,itMu->userFloat("PtbeforeRC") );
-    }
-    if(itMu->hasUserFloat("roccorSF")){
-      vars.FillVars( "Muon_roccorSF",iMu,itMu->userFloat("roccorSF") );
-    }
-    if(itMu->hasUserFloat("roccorSFUp")){
-      vars.FillVars( "Muon_roccorSFUp",iMu,itMu->userFloat("roccorSFUp") );
-    }
-    if(itMu->hasUserFloat("roccorSFDown")){
-      vars.FillVars( "Muon_roccorSFDown",iMu,itMu->userFloat("roccorSFDown") );
+    
+
+    
+    // Tagged Jets
+    for(std::vector<pat::Jet>::iterator itTaggedJet = selectedTaggedJets.begin() ; itTaggedJet != selectedTaggedJets.end(); ++itTaggedJet)
+    {
+        int iTaggedJet = itTaggedJet - selectedTaggedJets.begin();
+        vars.FillVars( "TaggedJet_E",iTaggedJet,            itTaggedJet->energy() );
+        vars.FillVars( "TaggedJet_M",iTaggedJet,            itTaggedJet->mass() );
+        vars.FillVars( "TaggedJet_Pt",iTaggedJet,           itTaggedJet->pt() );
+        vars.FillVars( "TaggedJet_Eta",iTaggedJet,          itTaggedJet->eta() );
+        vars.FillVars( "TaggedJet_Phi",iTaggedJet,          itTaggedJet->phi() );
+        vars.FillVars( "TaggedJet_CSV",iTaggedJet,          CSVHelper::GetJetCSV(*itTaggedJet,btagger));
+        vars.FillVars( "TaggedJet_DeepJetCSV",iTaggedJet,   CSVHelper::GetJetCSV_DNN(*itTaggedJet,"DeepJet"));
+        vars.FillVars( "TaggedJet_DeepJet_b",iTaggedJet,    CSVHelper::GetJetCSV_DNN(*itTaggedJet,"pfDeepFlavourJetTags:probb"));
+        vars.FillVars( "TaggedJet_DeepJet_bb",iTaggedJet,   CSVHelper::GetJetCSV_DNN(*itTaggedJet,"pfDeepFlavourJetTags:probbb"));
+        vars.FillVars( "TaggedJet_DeepJet_lepb",iTaggedJet, CSVHelper::GetJetCSV_DNN(*itTaggedJet,"pfDeepFlavourJetTags:problepb"));
+        vars.FillVars( "TaggedJet_DeepJet_c",iTaggedJet,    CSVHelper::GetJetCSV_DNN(*itTaggedJet,"pfDeepFlavourJetTags:probc"));
+        vars.FillVars( "TaggedJet_DeepJet_uds",iTaggedJet,  CSVHelper::GetJetCSV_DNN(*itTaggedJet,"pfDeepFlavourJetTags:probuds"));
+        vars.FillVars( "TaggedJet_DeepJet_g",iTaggedJet,    CSVHelper::GetJetCSV_DNN(*itTaggedJet,"pfDeepFlavourJetTags:probg"));
     }
 
-    if(itMu->hasUserFloat("IdentificationSF")){
-        vars.FillVars( "Muon_IdentificationSF",iMu,itMu->userFloat("IdentificationSF"));
-        vars.FillVars( "Muon_IdentificationSFUp",iMu,itMu->userFloat("IdentificationSFUp"));
-        vars.FillVars( "Muon_IdentificationSFDown",iMu,itMu->userFloat("IdentificationSFDown"));
+    // Fill Lepton Variables
+    std::vector<math::XYZTLorentzVector> tightLeptonVecs = BoostedUtils::GetLepVecs(input.selectedElectrons,input.selectedMuons);
+    for(auto itLep = tightLeptonVecs.begin(); itLep != tightLeptonVecs.end(); ++itLep)
+    {
+        int iLep = itLep - tightLeptonVecs.begin();
+        vars.FillVars( "TightLepton_E",iLep,itLep->E() );
+        vars.FillVars( "TightLepton_M",iLep,itLep->M() );
+        vars.FillVars( "TightLepton_Pt",iLep,itLep->Pt() );
+        vars.FillVars( "TightLepton_Eta",iLep,itLep->Eta());
+        vars.FillVars( "TightLepton_Phi",iLep,itLep->Phi() );
     }
-    if(itMu->hasUserFloat("IsolationSF")){
-        vars.FillVars( "Muon_IsolationSF",iMu,itMu->userFloat("IsolationSF"));
-        vars.FillVars( "Muon_IsolationSFUp",iMu,itMu->userFloat("IsolationSFUp"));
-        vars.FillVars( "Muon_IsolationSFDown",iMu,itMu->userFloat("IsolationSFDown"));
+    std::vector<math::XYZTLorentzVector> looseLeptonVecs = BoostedUtils::GetLepVecs(input.selectedElectronsLoose,input.selectedMuonsLoose);
+    for(std::vector<math::XYZTLorentzVector>::iterator itLep = looseLeptonVecs.begin() ; itLep != looseLeptonVecs.end(); ++itLep)
+    {
+        int iLep = itLep - looseLeptonVecs.begin();
+        vars.FillVars( "LooseLepton_E",iLep,itLep->E() );
+        vars.FillVars( "LooseLepton_M",iLep,itLep->M() );
+        vars.FillVars( "LooseLepton_Pt",iLep,itLep->Pt() );
+        vars.FillVars( "LooseLepton_Eta",iLep,itLep->Eta());
+        vars.FillVars( "LooseLepton_Phi",iLep,itLep->Phi() );
     }
-  }
-  
-  vars.FillVar( "Evt_MET_Pt",input.correctedMET.corPt(pat::MET::Type1XY) );
-  vars.FillVar( "Evt_MET_Phi",input.correctedMET.corPhi(pat::MET::Type1XY) );
-  if(input.correctedMET.genMET()!=0){
-      vars.FillVar( "Gen_MET_Pt",input.correctedMET.genMET()->pt() );
-      vars.FillVar( "Gen_MET_Phi",input.correctedMET.genMET()->phi() );
-  }
-  
-  //std::vector<math::XYZTLorentzVector> jetvecs = BoostedUtils::GetJetVecs(input.selectedJets);
-  //math::XYZTLorentzVector metvec = input.correctedMET.corP4(pat::MET::Type1XY);
-  
-  // Fill Number of b Tags
-  vars.FillVar( "N_BTagsM",selectedTaggedJets.size() );  
-  vars.FillVar( "N_BTagsL",selectedTaggedJetsL.size() );  
-  vars.FillVar( "N_BTagsT",selectedTaggedJetsT.size() );
-  
-  // Fill CSV Variables
-  std::vector<double> csvJets;
-  for(std::vector<pat::Jet>::const_iterator itJet = input.selectedJets.begin() ; itJet != input.selectedJets.end(); ++itJet){
-    csvJets.push_back(CSVHelper::GetJetCSV(*itJet,btagger));
-  }
+     
+    for(std::vector<pat::Electron>::const_iterator itEle = input.selectedElectronsLoose.begin(); itEle != input.selectedElectronsLoose.end(); ++itEle)
+    {
+        int iEle = itEle - input.selectedElectronsLoose.begin();
+        vars.FillVars( "LooseElectron_E",iEle,itEle->energy() );
+        vars.FillVars( "LooseElectron_M",iEle,itEle->mass() );
+        vars.FillVars( "LooseElectron_Pt",iEle,itEle->pt() );
+        vars.FillVars( "LooseElectron_Eta",iEle,itEle->eta() );
+        vars.FillVars( "LooseElectron_Phi",iEle,itEle->phi() ); 
+        if(itEle->hasUserFloat("relIso"))
+            vars.FillVars( "LooseElectron_RelIso",iEle,itEle->userFloat("relIso") );
 
-  std::vector<double> csvJetsSorted=csvJets;
-  std::sort(csvJetsSorted.begin(),csvJetsSorted.end(),std::greater<double>());
-  
-  for(std::vector<double>::iterator itCSV = csvJetsSorted.begin() ; itCSV != csvJetsSorted.end(); ++itCSV){
-    int iCSV = itCSV - csvJetsSorted.begin();
-    vars.FillVars("CSV" ,iCSV,*itCSV);
-  }
+        vars.FillVars( "LooseElectron_Charge",iEle,itEle->charge() ); 
+        if(itEle->hasUserFloat("ptBeforeRun2Calibration"))
+            vars.FillVars("LooseElectron_Pt_BeforeRun2Calibration",iEle,itEle->userFloat("ptBeforeRun2Calibration"));
+
+        vars.FillVars("LooseElectron_Eta_Supercluster",iEle,itEle->superCluster()->eta());
+        if(itEle->hasUserFloat("CorrFactor_ScaleUp"))
+        {
+            // electron energy scale combined up/down
+            vars.FillVars( "LooseElectron_CorrFactor_ScaleUp",iEle,itEle->userFloat("CorrFactor_ScaleUp"));
+            vars.FillVars( "LooseElectron_CorrFactor_ScaleDown",iEle,itEle->userFloat("CorrFactor_ScaleDown"));
+            // electron energy smearing combined up/down
+            vars.FillVars( "LooseElectron_CorrFactor_SigmaUp",iEle,itEle->userFloat("CorrFactor_SigmaUp"));
+            vars.FillVars( "LooseElectron_CorrFactor_SigmaDown",iEle,itEle->userFloat("CorrFactor_SigmaDown"));
+        }
+        if(itEle->hasUserFloat("IdentificationSF")) 
+        {
+            vars.FillVars( "LooseElectron_IdentificationSF",iEle,itEle->userFloat("IdentificationSF"));
+            vars.FillVars( "LooseElectron_IdentificationSFUp",iEle,itEle->userFloat("IdentificationSFUp"));
+            vars.FillVars( "LooseElectron_IdentificationSFDown",iEle,itEle->userFloat("IdentificationSFDown"));
+            vars.FillVars( "LooseElectron_ReconstructionSF",iEle,itEle->userFloat("ReconstructionSF"));
+            vars.FillVars( "LooseElectron_ReconstructionSFUp",iEle,itEle->userFloat("ReconstructionSFUp"));
+            vars.FillVars( "LooseElectron_ReconstructionSFDown",iEle,itEle->userFloat("ReconstructionSFDown"));
+        }
+    }
+    for(std::vector<pat::Electron>::const_iterator itEle = input.selectedElectrons.begin(); itEle != input.selectedElectrons.end(); ++itEle)
+    {
+        int iEle = itEle - input.selectedElectrons.begin();
+        vars.FillVars( "Electron_E",iEle,itEle->energy() );
+        vars.FillVars( "Electron_M",iEle,itEle->mass() );
+        vars.FillVars( "Electron_Pt",iEle,itEle->pt() );
+        vars.FillVars( "Electron_Eta",iEle,itEle->eta() );
+        vars.FillVars( "Electron_Phi",iEle,itEle->phi() ); 
+        if(itEle->hasUserFloat("relIso"))
+            vars.FillVars( "Electron_RelIso",iEle,itEle->userFloat("relIso") );
+
+        vars.FillVars( "Electron_Charge",iEle,itEle->charge() ); 
+        if(itEle->hasUserFloat("ptBeforeRun2Calibration"))
+            vars.FillVars("Electron_Pt_BeforeRun2Calibration",iEle,itEle->userFloat("ptBeforeRun2Calibration"));
+        
+        vars.FillVars("Electron_Eta_Supercluster",iEle,itEle->superCluster()->eta());
+        if(itEle->hasUserFloat("CorrFactor_ScaleUp"))
+        {
+            // electron energy scale combined up/down
+            vars.FillVars( "Electron_CorrFactor_ScaleUp",iEle,itEle->userFloat("CorrFactor_ScaleUp"));
+            vars.FillVars( "Electron_CorrFactor_ScaleDown",iEle,itEle->userFloat("CorrFactor_ScaleDown"));
+            // electron energy smearing combined up/down
+            vars.FillVars( "Electron_CorrFactor_SigmaUp",iEle,itEle->userFloat("CorrFactor_SigmaUp"));
+            vars.FillVars( "Electron_CorrFactor_SigmaDown",iEle,itEle->userFloat("CorrFactor_SigmaDown"));
+        }
+        if(itEle->hasUserFloat("IdentificationSF"))
+        {
+            vars.FillVars( "Electron_IdentificationSF",iEle,itEle->userFloat("IdentificationSF"));
+            vars.FillVars( "Electron_IdentificationSFUp",iEle,itEle->userFloat("IdentificationSFUp"));
+            vars.FillVars( "Electron_IdentificationSFDown",iEle,itEle->userFloat("IdentificationSFDown"));
+            vars.FillVars( "Electron_ReconstructionSF",iEle,itEle->userFloat("ReconstructionSF"));
+            vars.FillVars( "Electron_ReconstructionSFUp",iEle,itEle->userFloat("ReconstructionSFUp"));
+            vars.FillVars( "Electron_ReconstructionSFDown",iEle,itEle->userFloat("ReconstructionSFDown"));
+        }
+    }
+    
+    for(std::vector<pat::Muon>::const_iterator itMu = input.selectedMuonsLoose.begin(); itMu != input.selectedMuonsLoose.end(); ++itMu)
+    {
+        int iMu = itMu - input.selectedMuonsLoose.begin();
+        vars.FillVars( "LooseMuon_E",iMu,itMu->energy() );
+        vars.FillVars( "LooseMuon_M",iMu,itMu->mass() );
+        vars.FillVars( "LooseMuon_Pt",iMu,itMu->pt() );
+        vars.FillVars( "LooseMuon_Eta",iMu,itMu->eta() );
+        vars.FillVars( "LooseMuon_Phi",iMu,itMu->phi() );
+        if(itMu->hasUserFloat("relIso"))
+            vars.FillVars( "LooseMuon_RelIso",iMu,itMu->userFloat("relIso") );
+
+        vars.FillVars( "LooseMuon_Charge",iMu,itMu->charge() );
+        if(itMu->hasUserFloat("PtbeforeRC"))
+            vars.FillVars( "LooseMuon_Pt_BeForeRC",iMu,itMu->userFloat("PtbeforeRC") );
+
+        if(itMu->hasUserFloat("roccorSF"))
+            vars.FillVars( "LooseMuon_roccorSF",iMu,itMu->userFloat("roccorSF") );
+
+        if(itMu->hasUserFloat("roccorSFUp"))
+            vars.FillVars( "LooseMuon_roccorSFUp",iMu,itMu->userFloat("roccorSFUp") );
+
+        if(itMu->hasUserFloat("roccorSFDown"))
+            vars.FillVars( "LooseMuon_roccorSFDown",iMu,itMu->userFloat("roccorSFDown") );
+
+        if(itMu->hasUserFloat("IdentificationSF"))
+        {
+            vars.FillVars( "LooseMuon_IdentificationSF",iMu,itMu->userFloat("IdentificationSF"));
+            vars.FillVars( "LooseMuon_IdentificationSFUp",iMu,itMu->userFloat("IdentificationSFUp"));
+            vars.FillVars( "LooseMuon_IdentificationSFDown",iMu,itMu->userFloat("IdentificationSFDown"));
+        }
+        if(itMu->hasUserFloat("IsolationSF"))
+        {
+            vars.FillVars( "LooseMuon_IsolationSF",iMu,itMu->userFloat("IsolationSF"));
+            vars.FillVars( "LooseMuon_IsolationSFUp",iMu,itMu->userFloat("IsolationSFUp"));
+            vars.FillVars( "LooseMuon_IsolationSFDown",iMu,itMu->userFloat("IsolationSFDown"));
+        }
+    }
+    for(std::vector<pat::Muon>::const_iterator itMu = input.selectedMuons.begin(); itMu != input.selectedMuons.end(); ++itMu)
+    {
+        int iMu = itMu - input.selectedMuons.begin();
+        vars.FillVars( "Muon_E",iMu,itMu->energy() );
+        vars.FillVars( "Muon_M",iMu,itMu->mass() );
+        vars.FillVars( "Muon_Pt",iMu,itMu->pt() );
+        vars.FillVars( "Muon_Eta",iMu,itMu->eta() );
+        vars.FillVars( "Muon_Phi",iMu,itMu->phi() );
+        if(itMu->hasUserFloat("relIso"))
+            vars.FillVars( "Muon_RelIso",iMu,itMu->userFloat("relIso") );
+
+        vars.FillVars( "Muon_Charge",iMu,itMu->charge() );
+        if(itMu->hasUserFloat("PtbeforeRC"))
+            vars.FillVars( "Muon_Pt_BeForeRC",iMu,itMu->userFloat("PtbeforeRC") );
+
+        if(itMu->hasUserFloat("roccorSF"))
+            vars.FillVars( "Muon_roccorSF",iMu,itMu->userFloat("roccorSF") );
+
+        if(itMu->hasUserFloat("roccorSFUp"))
+            vars.FillVars( "Muon_roccorSFUp",iMu,itMu->userFloat("roccorSFUp") );
+
+        if(itMu->hasUserFloat("roccorSFDown"))
+            vars.FillVars( "Muon_roccorSFDown",iMu,itMu->userFloat("roccorSFDown") );
+
+
+        if(itMu->hasUserFloat("IdentificationSF"))
+        {
+            vars.FillVars( "Muon_IdentificationSF",iMu,itMu->userFloat("IdentificationSF"));
+            vars.FillVars( "Muon_IdentificationSFUp",iMu,itMu->userFloat("IdentificationSFUp"));
+            vars.FillVars( "Muon_IdentificationSFDown",iMu,itMu->userFloat("IdentificationSFDown"));
+        }
+        if(itMu->hasUserFloat("IsolationSF"))
+        {
+            vars.FillVars( "Muon_IsolationSF",iMu,itMu->userFloat("IsolationSF"));
+            vars.FillVars( "Muon_IsolationSFUp",iMu,itMu->userFloat("IsolationSFUp"));
+            vars.FillVars( "Muon_IsolationSFDown",iMu,itMu->userFloat("IsolationSFDown"));
+        }
+    }
+    
+    vars.FillVar( "Evt_MET_Pt",input.correctedMET.corPt(pat::MET::Type1XY) );
+    vars.FillVar( "Evt_MET_Phi",input.correctedMET.corPhi(pat::MET::Type1XY) );
+    if(input.correctedMET.genMET()!=0)
+    {
+        vars.FillVar( "Gen_MET_Pt",input.correctedMET.genMET()->pt() );
+        vars.FillVar( "Gen_MET_Phi",input.correctedMET.genMET()->phi() );
+    }
+    
+    //std::vector<math::XYZTLorentzVector> jetvecs = BoostedUtils::GetJetVecs(input.selectedJets);
+    //math::XYZTLorentzVector metvec = input.correctedMET.corP4(pat::MET::Type1XY);
+    
+    // Fill Number of b Tags
+    vars.FillVar( "N_BTagsM",selectedTaggedJets.size() );    
+    vars.FillVar( "N_BTagsL",selectedTaggedJetsL.size() );    
+    vars.FillVar( "N_BTagsT",selectedTaggedJetsT.size() );
+    
+    // Fill CSV Variables
+    std::vector<double> csvJets;
+    for(std::vector<pat::Jet>::const_iterator itJet = input.selectedJets.begin() ; itJet != input.selectedJets.end(); ++itJet)
+        csvJets.push_back(CSVHelper::GetJetCSV(*itJet,btagger));
+
+
+    std::vector<double> csvJetsSorted=csvJets;
+    std::sort(csvJetsSorted.begin(),csvJetsSorted.end(),std::greater<double>());
+    
+    for(std::vector<double>::iterator itCSV = csvJetsSorted.begin() ; itCSV != csvJetsSorted.end(); ++itCSV)
+    {
+        int iCSV = itCSV - csvJetsSorted.begin();
+        vars.FillVars("CSV" ,iCSV,*itCSV);
+    }
 
 }

--- a/BoostedAnalyzer/src/essentialBasicVarProcessor.cpp
+++ b/BoostedAnalyzer/src/essentialBasicVarProcessor.cpp
@@ -40,7 +40,6 @@ void essentialBasicVarProcessor::Init(const InputCollections& input,VariableCont
   vars.InitVars( "LooseJet_Phi","N_LooseJets" );
   vars.InitVars( "LooseJet_Eta","N_LooseJets" );
   vars.InitVars( "LooseJet_CSV","N_LooseJets" );
-  //vars.InitVars( "LooseJet_CSV_DNN","N_LooseJets" );
   vars.InitVars( "LooseJet_Flav","N_LooseJets" );
   vars.InitVars( "LooseJet_PartonFlav","N_LooseJets" );
   vars.InitVars( "LooseJet_Charge","N_LooseJets" );
@@ -69,7 +68,6 @@ void essentialBasicVarProcessor::Init(const InputCollections& input,VariableCont
   vars.InitVars( "Jet_Phi","N_Jets" );
   vars.InitVars( "Jet_Eta","N_Jets" );
   vars.InitVars( "Jet_CSV","N_Jets" );
-  //vars.InitVars( "Jet_CSV_DNN","N_Jets" );
   vars.InitVars( "Jet_Flav","N_Jets" );
   vars.InitVars( "Jet_PartonFlav","N_Jets" );
   vars.InitVars( "Jet_Charge","N_Jets" );
@@ -190,17 +188,13 @@ void essentialBasicVarProcessor::Init(const InputCollections& input,VariableCont
   
   
   
-  vars.InitVar( "Evt_Pt_MET" );
-  vars.InitVar( "Evt_Phi_MET" );
-  vars.InitVar( "Evt_Pt_GenMET" );
-  vars.InitVar( "Evt_Phi_GenMET" );
-
+  vars.InitVar( "Evt_MET_Pt" );
+  vars.InitVar( "Evt_MET_Phi" );
+  vars.InitVar( "Gen_MET_Pt" );
+  vars.InitVar( "Gen_MET_Phi" );
   
-  
-  vars.InitVar("Evt_M_Total");
   
   vars.InitVars( "CSV","N_Jets" );
-//vars.InitVars( "CSV_DNN","N_Jets" );
   initialized=true;
 }
 
@@ -261,7 +255,6 @@ void essentialBasicVarProcessor::Process(const InputCollections& input,VariableC
     vars.FillVars( "Jet_Eta",iJet,itJet->eta() );
     vars.FillVars( "Jet_Phi",iJet,itJet->phi() );
     vars.FillVars( "Jet_CSV",iJet,CSVHelper::GetJetCSV(*itJet,btagger) );
-    //vars.FillVars( "Jet_CSV_DNN",iJet,CSVHelper::GetJetCSV_DNN(*itJet,btagger) );
     vars.FillVars( "Jet_Flav",iJet,itJet->hadronFlavour() );
     vars.FillVars( "Jet_PartonFlav",iJet,itJet->partonFlavour() );
     vars.FillVars( "Jet_Charge",iJet,itJet->jetCharge() );
@@ -494,26 +487,15 @@ void essentialBasicVarProcessor::Process(const InputCollections& input,VariableC
     }
   }
   
-  vars.FillVar( "Evt_Pt_MET",input.correctedMET.corPt(pat::MET::Type1XY) );
-  vars.FillVar( "Evt_Phi_MET",input.correctedMET.corPhi(pat::MET::Type1XY) );
+  vars.FillVar( "Evt_MET_Pt",input.correctedMET.corPt(pat::MET::Type1XY) );
+  vars.FillVar( "Evt_MET_Phi",input.correctedMET.corPhi(pat::MET::Type1XY) );
   if(input.correctedMET.genMET()!=0){
-      vars.FillVar( "Evt_Pt_GenMET",input.correctedMET.genMET()->pt() );
-      vars.FillVar( "Evt_Phi_GenMET",input.correctedMET.genMET()->phi() );
+      vars.FillVar( "Gen_MET_Pt",input.correctedMET.genMET()->pt() );
+      vars.FillVar( "Gen_MET_Phi",input.correctedMET.genMET()->phi() );
   }
   
-  std::vector<math::XYZTLorentzVector> jetvecs = BoostedUtils::GetJetVecs(input.selectedJets);
-  math::XYZTLorentzVector metvec = input.correctedMET.corP4(pat::MET::Type1XY);
-
-  // Fill Event Mass
-  math::XYZTLorentzVector p4all;
-  for(std::vector<math::XYZTLorentzVector>::iterator itJetVec = jetvecs.begin() ; itJetVec != jetvecs.end(); ++itJetVec){
-    p4all += *itJetVec;
-  }
-  for(std::vector<math::XYZTLorentzVector>::iterator itLep = looseLeptonVecs.begin() ; itLep != looseLeptonVecs.end(); ++itLep){
-    p4all += *itLep;
-  }
-  p4all += metvec;
-  vars.FillVar("Evt_M_Total",p4all.M());
+  //std::vector<math::XYZTLorentzVector> jetvecs = BoostedUtils::GetJetVecs(input.selectedJets);
+  //math::XYZTLorentzVector metvec = input.correctedMET.corP4(pat::MET::Type1XY);
   
   // Fill Number of b Tags
   vars.FillVar( "N_BTagsM",selectedTaggedJets.size() );  
@@ -521,25 +503,17 @@ void essentialBasicVarProcessor::Process(const InputCollections& input,VariableC
   vars.FillVar( "N_BTagsT",selectedTaggedJetsT.size() );
   
   // Fill CSV Variables
-  // All Jets
   std::vector<double> csvJets;
-  //std::vector<double> csvJets_DNN;
   for(std::vector<pat::Jet>::const_iterator itJet = input.selectedJets.begin() ; itJet != input.selectedJets.end(); ++itJet){
     csvJets.push_back(CSVHelper::GetJetCSV(*itJet,btagger));
-    //csvJets_DNN.push_back(CSVHelper::GetJetCSV_DNN(*itJet,btagger));
   }
+
   std::vector<double> csvJetsSorted=csvJets;
-  //std::vector<double> csvJetsSorted_DNN=csvJets_DNN;
   std::sort(csvJetsSorted.begin(),csvJetsSorted.end(),std::greater<double>());
-  //std::sort(csvJetsSorted_DNN.begin(),csvJetsSorted_DNN.end(),std::greater<double>());
   
   for(std::vector<double>::iterator itCSV = csvJetsSorted.begin() ; itCSV != csvJetsSorted.end(); ++itCSV){
     int iCSV = itCSV - csvJetsSorted.begin();
     vars.FillVars("CSV" ,iCSV,*itCSV);
   }
-  //for(std::vector<double>::iterator itCSV = csvJetsSorted_DNN.begin() ; itCSV != csvJetsSorted_DNN.end(); ++itCSV){
-  //  int iCSV = itCSV - csvJetsSorted_DNN.begin();
-  //  vars.FillVars("CSV" ,iCSV,*itCSV);
-  //}
 
 }

--- a/BoostedAnalyzer/src/essentialBasicVarProcessor.cpp
+++ b/BoostedAnalyzer/src/essentialBasicVarProcessor.cpp
@@ -197,8 +197,6 @@ void essentialBasicVarProcessor::Init(const InputCollections& input,VariableCont
 
   
   
-  vars.InitVar("Evt_M3");
-//vars.InitVar("Evt_M3_OneJetTagged");
   vars.InitVar("Evt_MTW");
   vars.InitVar("Evt_HT");
   vars.InitVar("Evt_HT_Jets");
@@ -507,43 +505,6 @@ void essentialBasicVarProcessor::Process(const InputCollections& input,VariableC
       vars.FillVar( "Evt_Phi_GenMET",input.correctedMET.genMET()->phi() );
   }
   
-  std::vector<math::XYZTLorentzVector> jetvecs = BoostedUtils::GetJetVecs(input.selectedJets);
-  math::XYZTLorentzVector metvec = input.correctedMET.corP4(pat::MET::Type1XY);
-  
-  // Fill M3 Variables
-  float m3 = -1.;
-  float maxpt=-1;
-  for(std::vector<math::XYZTLorentzVector>::iterator itJetVec1 = jetvecs.begin() ; itJetVec1 != jetvecs.end(); ++itJetVec1){
-    for(std::vector<math::XYZTLorentzVector>::iterator itJetVec2 = itJetVec1+1 ; itJetVec2 != jetvecs.end(); ++itJetVec2){
-      for(std::vector<math::XYZTLorentzVector>::iterator itJetVec3 = itJetVec2+1 ; itJetVec3 != jetvecs.end(); ++itJetVec3){
-    
-        math::XYZTLorentzVector m3vec = *itJetVec1 + *itJetVec2 + *itJetVec3;
-        
-	      if(m3vec.Pt() > maxpt){
-	        maxpt = m3vec.Pt();
-	        m3 = m3vec.M();
-	      }
-      } 
-    }
-  }
-  vars.FillVar("Evt_M3",m3);
-//   float m3tagged = -1.;
-  float maxpttagged=-1.;
-  for(std::vector<pat::Jet>::iterator itJetUntagged1 = selectedUntaggedJets.begin() ; itJetUntagged1 != selectedUntaggedJets.end(); ++itJetUntagged1){
-    for(std::vector<pat::Jet>::iterator itJetUntagged2 = itJetUntagged1+1 ; itJetUntagged2 != selectedUntaggedJets.end(); ++itJetUntagged2){
-      for(std::vector<pat::Jet>::iterator itJetTagged = selectedTaggedJets.begin() ; itJetTagged != selectedTaggedJets.end(); ++itJetTagged){
-        
-        math::XYZTLorentzVector m3vec = itJetUntagged1->p4() + itJetUntagged2->p4() + itJetTagged->p4();
-	      
-        if(m3vec.Pt() > maxpttagged){
-	        maxpttagged = m3vec.Pt();
-// 	        m3tagged = m3vec.M();
-	      }
-      } 
-    }
-  }
- 
-//   vars.FillVar("Evt_M3_OneJetTagged",m3tagged);
   // Fill MTW
   math::XYZTLorentzVector primLepVec = math::XYZTLorentzVector();
   float mtw = -1.;

--- a/BoostedAnalyzer/src/essentialBasicVarProcessor.cpp
+++ b/BoostedAnalyzer/src/essentialBasicVarProcessor.cpp
@@ -198,10 +198,7 @@ void essentialBasicVarProcessor::Init(const InputCollections& input,VariableCont
   
   
   vars.InitVar("Evt_MTW");
-  vars.InitVar("Evt_HT");
-  vars.InitVar("Evt_HT_Jets");
   vars.InitVar("Evt_M_Total");
-  vars.InitVar("Evt_MHT");
   
   vars.InitVars( "CSV","N_Jets" );
 //vars.InitVars( "CSV_DNN","N_Jets" );
@@ -515,35 +512,6 @@ void essentialBasicVarProcessor::Process(const InputCollections& input,VariableC
     mtw = sqrt(2*(primLepVec.Pt()*input.correctedMET.corPt(pat::MET::Type1XY) - primLepVec.Px()*input.correctedMET.corPx(pat::MET::Type1XY) - primLepVec.Py()*input.correctedMET.corPy(pat::MET::Type1XY)));
   }
   vars.FillVar("Evt_MTW",mtw);
-  
-  // Fill Ht Variables
-  float ht = 0.;
-  float htjets = 0.;
-  float mht_px = 0.;
-  float mht_py = 0.;
-  for(std::vector<pat::Jet>::const_iterator itJet = input.selectedJets.begin() ; itJet != input.selectedJets.end(); ++itJet){
-    ht += itJet->pt();
-    htjets += itJet->pt();
-    mht_px += itJet->px();
-    mht_py += itJet->py();
-  }
-  for(std::vector<pat::Electron>::const_iterator itEle = input.selectedElectronsLoose.begin(); itEle != input.selectedElectronsLoose.end(); ++itEle){
-    ht += itEle->pt();
-    mht_px += itEle->px();
-    mht_py += itEle->py();
-    
-  }
-  for(std::vector<pat::Muon>::const_iterator itMu = input.selectedMuonsLoose.begin(); itMu != input.selectedMuonsLoose.end(); ++itMu){
-    ht += itMu->pt();
-    mht_px += itMu->px();
-    mht_py += itMu->py();
-    
-  }
-  ht += input.correctedMET.corPt(pat::MET::Type1XY);
-  
-  vars.FillVar("Evt_HT",ht);
-  vars.FillVar("Evt_MHT",sqrt( mht_px*mht_px + mht_py*mht_py ));
-  vars.FillVar("Evt_HT_Jets",htjets);
   
   // Fill Event Mass
   math::XYZTLorentzVector p4all;

--- a/BoostedAnalyzer/src/essentialBasicVarProcessor.cpp
+++ b/BoostedAnalyzer/src/essentialBasicVarProcessor.cpp
@@ -505,6 +505,9 @@ void essentialBasicVarProcessor::Process(const InputCollections& input,VariableC
       vars.FillVar( "Evt_Phi_GenMET",input.correctedMET.genMET()->phi() );
   }
   
+  std::vector<math::XYZTLorentzVector> jetvecs = BoostedUtils::GetJetVecs(input.selectedJets);
+  math::XYZTLorentzVector metvec = input.correctedMET.corP4(pat::MET::Type1XY);
+
   // Fill MTW
   math::XYZTLorentzVector primLepVec = math::XYZTLorentzVector();
   float mtw = -1.;

--- a/BoostedAnalyzer/src/essentialBasicVarProcessor.cpp
+++ b/BoostedAnalyzer/src/essentialBasicVarProcessor.cpp
@@ -197,7 +197,6 @@ void essentialBasicVarProcessor::Init(const InputCollections& input,VariableCont
 
   
   
-  vars.InitVar("Evt_MTW");
   vars.InitVar("Evt_M_Total");
   
   vars.InitVars( "CSV","N_Jets" );
@@ -505,14 +504,6 @@ void essentialBasicVarProcessor::Process(const InputCollections& input,VariableC
   std::vector<math::XYZTLorentzVector> jetvecs = BoostedUtils::GetJetVecs(input.selectedJets);
   math::XYZTLorentzVector metvec = input.correctedMET.corP4(pat::MET::Type1XY);
 
-  // Fill MTW
-  math::XYZTLorentzVector primLepVec = math::XYZTLorentzVector();
-  float mtw = -1.;
-  if(input.selectedElectrons.size()>0 || input.selectedMuons.size()>0){
-    mtw = sqrt(2*(primLepVec.Pt()*input.correctedMET.corPt(pat::MET::Type1XY) - primLepVec.Px()*input.correctedMET.corPx(pat::MET::Type1XY) - primLepVec.Py()*input.correctedMET.corPy(pat::MET::Type1XY)));
-  }
-  vars.FillVar("Evt_MTW",mtw);
-  
   // Fill Event Mass
   math::XYZTLorentzVector p4all;
   for(std::vector<math::XYZTLorentzVector>::iterator itJetVec = jetvecs.begin() ; itJetVec != jetvecs.end(); ++itJetVec){

--- a/BoostedAnalyzer/src/essentialMVAVarProcessor.cpp
+++ b/BoostedAnalyzer/src/essentialMVAVarProcessor.cpp
@@ -21,13 +21,6 @@ void essentialMVAVarProcessor::Init(const InputCollections &input, VariableConta
   vars.InitVar("Evt_Eta_PrimaryLepton");
   vars.InitVar("Evt_Phi_PrimaryLepton");
 
-  vars.InitVar("Evt_CSV_Average");
-  vars.InitVar("Evt_CSV_Min");
-  vars.InitVar("Evt_CSV_Dev");
-  vars.InitVar("Evt_CSV_Average_Tagged");
-  vars.InitVar("Evt_CSV_Min_Tagged");
-  vars.InitVar("Evt_CSV_Dev_Tagged");
-
   vars.InitVar("Evt_M_MinDeltaRJets");
   vars.InitVar("Evt_M_MinDeltaRTaggedJets");
   vars.InitVar("Evt_M_MinDeltaRUntaggedJets");
@@ -134,26 +127,7 @@ void essentialMVAVarProcessor::Process(const InputCollections &input, VariableCo
   }
   std::vector<double> csvJetsSorted = csvJets;
   std::sort(csvJetsSorted.begin(), csvJetsSorted.end(), std::greater<double>());
-  vars.FillVar("Evt_CSV_Min", csvJetsSorted.size() > 0 ? csvJetsSorted.back() : -.1);
 
-  float averageCSV = 0;
-  for (std::vector<double>::iterator itCSV = csvJetsSorted.begin(); itCSV != csvJetsSorted.end(); ++itCSV)
-  {
-    averageCSV += fmax(*itCSV, 0);
-  }
-  averageCSV /= csvJetsSorted.size();
-  vars.FillVar("Evt_CSV_Average", averageCSV);
-
-  float csvDev = 0;
-  for (std::vector<double>::iterator itCSV = csvJetsSorted.begin(); itCSV != csvJetsSorted.end(); ++itCSV)
-  {
-    csvDev += fabs(pow(*itCSV - averageCSV, 2));
-  }
-  if (csvJetsSorted.size() > 0)
-    csvDev /= csvJetsSorted.size();
-  else
-    csvDev = -1.;
-  vars.FillVar("Evt_CSV_Dev", csvDev);
 
   // Tagged Jets
   vector<float> csvTaggedJets;
@@ -162,27 +136,7 @@ void essentialMVAVarProcessor::Process(const InputCollections &input, VariableCo
     csvTaggedJets.push_back(CSVHelper::GetJetCSV(*itTaggedJet, btagger));
   }
   sort(csvTaggedJets.begin(), csvTaggedJets.end(), std::greater<float>());
-  vars.FillVar("Evt_CSV_Min_Tagged", csvTaggedJets.size() > 0 ? csvTaggedJets.back() : -.1);
 
-  float averageCSVTagged = 0;
-  for (std::vector<float>::iterator itCSVTagged = csvTaggedJets.begin(); itCSVTagged != csvTaggedJets.end(); ++itCSVTagged)
-  {
-    averageCSVTagged += fmax(*itCSVTagged, 0);
-  }
-  averageCSVTagged /= csvTaggedJets.size();
-  vars.FillVar("Evt_CSV_Average_Tagged", averageCSVTagged);
-
-  float csvDevTagged = 0;
-  for (std::vector<float>::iterator itCSVTagged = csvTaggedJets.begin(); itCSVTagged != csvTaggedJets.end(); ++itCSVTagged)
-  {
-    csvDevTagged += fabs(pow(*itCSVTagged - averageCSVTagged, 2));
-  }
-  if (csvTaggedJets.size() > 0)
-    csvDevTagged /= csvTaggedJets.size();
-  else
-    csvDevTagged = -1.;
-
-  vars.FillVar("Evt_CSV_Dev_Tagged", csvDevTagged);
   // Fill Variables for closest ak4 Jets
   // All Jets
   if (input.selectedJets.size() > 1)

--- a/BoostedAnalyzer/src/essentialMVAVarProcessor.cpp
+++ b/BoostedAnalyzer/src/essentialMVAVarProcessor.cpp
@@ -21,20 +21,14 @@ void essentialMVAVarProcessor::Init(const InputCollections &input, VariableConta
   vars.InitVar("Evt_Eta_PrimaryLepton");
   vars.InitVar("Evt_Phi_PrimaryLepton");
 
-  vars.InitVar("Evt_M_MinDeltaRJets");
-  vars.InitVar("Evt_M_MinDeltaRTaggedJets");
   vars.InitVar("Evt_M_MinDeltaRUntaggedJets");
   vars.InitVar("Evt_M_MinDeltaRLeptonTaggedJet");
   vars.InitVar("Evt_M_MinDeltaRLeptonJet");
 
-  vars.InitVar("Evt_Dr_MinDeltaRJets");
-  vars.InitVar("Evt_Dr_MinDeltaRTaggedJets");
   vars.InitVar("Evt_Dr_MinDeltaRUntaggedJets");
   vars.InitVar("Evt_Dr_MinDeltaRLeptonTaggedJet");
   vars.InitVar("Evt_Dr_MinDeltaRLeptonJet");
 
-  vars.InitVar("Evt_Pt_MinDeltaRJets");
-  vars.InitVar("Evt_Pt_MinDeltaRTaggedJets");
   vars.InitVar("Evt_Pt_MinDeltaRUntaggedJets");
 
   vars.InitVar("Evt_M_JetsAverage");
@@ -45,25 +39,13 @@ void essentialMVAVarProcessor::Init(const InputCollections &input, VariableConta
   vars.InitVar("Evt_Eta_TaggedJetsAverage");
   vars.InitVar("Evt_Eta_UntaggedJetsAverage");
 
-  vars.InitVar("Evt_M2_JetsAverage");
-  vars.InitVar("Evt_M2_TaggedJetsAverage");
   vars.InitVar("Evt_M2_UntaggedJetsAverage");
 
-  vars.InitVar("Evt_Deta_JetsAverage");
-  vars.InitVar("Evt_Deta_TaggedJetsAverage");
   vars.InitVar("Evt_Deta_UntaggedJetsAverage");
 
-  vars.InitVar("Evt_Dr_JetsAverage");
-  vars.InitVar("Evt_Dr_TaggedJetsAverage");
   vars.InitVar("Evt_Dr_UntaggedJetsAverage");
 
-  vars.InitVar("Evt_M_TaggedJetsClosestTo125");
-
   vars.InitVar("Evt_JetPtOverJetE");
-
-  vars.InitVar("Evt_Jet_MaxDeta_Jets");
-  vars.InitVar("Evt_TaggedJet_MaxDeta_Jets");
-  vars.InitVar("Evt_TaggedJet_MaxDeta_TaggedJets");
 
   vars.InitVar("Evt_M_MedianTaggedJets");
 
@@ -127,30 +109,6 @@ void essentialMVAVarProcessor::Process(const InputCollections &input, VariableCo
   }
 
   // Fill Variables for closest ak4 Jets
-  // All Jets
-  if (input.selectedJets.size() > 1)
-  {
-    int idClosestJet1 = -1;
-    int idClosestJet2 = -1;
-    float minDrJets = BoostedUtils::GetClosestJetIDs(idClosestJet1, idClosestJet2, input.selectedJets);
-    math::XYZTLorentzVector closestJetVec1 = input.selectedJets[idClosestJet1].p4();
-    math::XYZTLorentzVector closestJetVec2 = input.selectedJets[idClosestJet2].p4();
-    vars.FillVar("Evt_M_MinDeltaRJets", (closestJetVec1 + closestJetVec2).M());
-    vars.FillVar("Evt_Dr_MinDeltaRJets", minDrJets);
-    vars.FillVar("Evt_Pt_MinDeltaRJets", (closestJetVec1 + closestJetVec2).Pt());
-  }
-  // Tagged Jets
-  if (selectedTaggedJets.size() > 1)
-  {
-    int idClosestTaggedJet1 = -1;
-    int idClosestTaggedJet2 = -1;
-    float minDrTaggedJets = BoostedUtils::GetClosestJetIDs(idClosestTaggedJet1, idClosestTaggedJet2, selectedTaggedJets);
-    math::XYZTLorentzVector closestTaggedJetVec1 = selectedTaggedJets[idClosestTaggedJet1].p4();
-    math::XYZTLorentzVector closestTaggedJetVec2 = selectedTaggedJets[idClosestTaggedJet2].p4();
-    vars.FillVar("Evt_M_MinDeltaRTaggedJets", (closestTaggedJetVec1 + closestTaggedJetVec2).M());
-    vars.FillVar("Evt_Dr_MinDeltaRTaggedJets", minDrTaggedJets);
-    vars.FillVar("Evt_Pt_MinDeltaRTaggedJets", (closestTaggedJetVec1 + closestTaggedJetVec2).Pt());
-  }
   // Untagged Jets
   if (selectedUntaggedJets.size() > 1)
   {
@@ -216,27 +174,14 @@ void essentialMVAVarProcessor::Process(const InputCollections &input, VariableCo
     mJetsAverage /= (float)jetvecs.size();
     etaJetsAverage /= (float)jetvecs.size();
   }
-  if (nPairsJets > 0)
-  {
-    m2JetsAverage /= (float)nPairsJets;
-    detaJetsAverage /= (float)nPairsJets;
-    drJetsAverage /= (float)nPairsJets;
-  }
   vars.FillVar("Evt_M_JetsAverage", mJetsAverage);
   vars.FillVar("Evt_Eta_JetsAverage", etaJetsAverage);
-  vars.FillVar("Evt_M2_JetsAverage", m2JetsAverage);
-  vars.FillVar("Evt_Deta_JetsAverage", detaJetsAverage);
-  vars.FillVar("Evt_Dr_JetsAverage", drJetsAverage);
   vars.FillVar("Evt_JetPtOverJetE", ptJetsAverage / eJetsAverage);
 
   // Tagged Jets
   float mTaggedJetsAverage = 0;
   float etaTaggedJetsAverage = 0;
-  float m2TaggedJetsAverage = 0;
   vector<float> m2TaggedJets;
-  float m2TaggedJetsClosestTo125 = -999;
-  float detaTaggedJetsAverage = 0;
-  float drTaggedJetsAverage = 0;
 
   int nPairsTaggedJets = 0;
   for (std::vector<pat::Jet>::iterator itTaggedJet1 = selectedTaggedJets.begin(); itTaggedJet1 != selectedTaggedJets.end(); ++itTaggedJet1)
@@ -251,11 +196,6 @@ void essentialMVAVarProcessor::Process(const InputCollections &input, VariableCo
       math::XYZTLorentzVector taggedJetVec2 = itTaggedJet2->p4();
 
       m2TaggedJets.push_back((taggedJetVec1 + taggedJetVec2).M());
-      m2TaggedJetsAverage += m2TaggedJets.back();
-      if (fabs(m2TaggedJets.back() - 125) < fabs(m2TaggedJetsClosestTo125 - 125))
-        m2TaggedJetsClosestTo125 = m2TaggedJets.back();
-      detaTaggedJetsAverage += fabs(taggedJetVec1.Eta() - taggedJetVec2.Eta());
-      drTaggedJetsAverage += BoostedUtils::DeltaR(taggedJetVec1, taggedJetVec2);
       nPairsTaggedJets++;
     }
   }
@@ -264,22 +204,12 @@ void essentialMVAVarProcessor::Process(const InputCollections &input, VariableCo
     mTaggedJetsAverage /= (float)selectedTaggedJets.size();
     etaTaggedJetsAverage /= (float)selectedTaggedJets.size();
   }
-  if (nPairsTaggedJets > 0)
-  {
-    m2TaggedJetsAverage /= (float)nPairsTaggedJets;
-    detaTaggedJetsAverage /= (float)nPairsTaggedJets;
-    drTaggedJetsAverage /= (float)nPairsTaggedJets;
-  }
   sort(m2TaggedJets.begin(), m2TaggedJets.end(), std::greater<float>());
 
   vars.FillVar("Evt_M_TaggedJetsAverage", mTaggedJetsAverage);
   vars.FillVar("Evt_Eta_TaggedJetsAverage", etaTaggedJetsAverage);
-  vars.FillVar("Evt_M2_TaggedJetsAverage", m2TaggedJetsAverage);
   if (m2TaggedJets.size() > 0)
     vars.FillVar("Evt_M_MedianTaggedJets", m2TaggedJets.at(m2TaggedJets.size() / 2));
-  vars.FillVar("Evt_M_TaggedJetsClosestTo125", m2TaggedJetsClosestTo125);
-  vars.FillVar("Evt_Deta_TaggedJetsAverage", detaTaggedJetsAverage);
-  vars.FillVar("Evt_Dr_TaggedJetsAverage", drTaggedJetsAverage);
 
   // Untagged Jets
   float mUntaggedJetsAverage = 0;
@@ -322,11 +252,6 @@ void essentialMVAVarProcessor::Process(const InputCollections &input, VariableCo
   vars.FillVar("Evt_M2_UntaggedJetsAverage", m2UntaggedJetsAverage);
   vars.FillVar("Evt_Deta_UntaggedJetsAverage", detaUntaggedJetsAverage);
   vars.FillVar("Evt_Dr_UntaggedJetsAverage", drUntaggedJetsAverage);
-
-  // DeltaEta of Jets
-  vars.FillVar("Evt_Jet_MaxDeta_Jets", BoostedUtils::GetJetAverageJetEtaMax(input.selectedJets, input.selectedJets));
-  vars.FillVar("Evt_TaggedJet_MaxDeta_Jets", BoostedUtils::GetJetAverageJetEtaMax(input.selectedJets, selectedTaggedJets));
-  vars.FillVar("Evt_TaggedJet_MaxDeta_TaggedJets", BoostedUtils::GetJetAverageJetEtaMax(selectedTaggedJets, selectedTaggedJets));
 
   // Ohio Variables
   std::vector<pat::Jet> selectedJetsLooseExclusive;

--- a/BoostedAnalyzer/src/essentialMVAVarProcessor.cpp
+++ b/BoostedAnalyzer/src/essentialMVAVarProcessor.cpp
@@ -125,17 +125,6 @@ void essentialMVAVarProcessor::Process(const InputCollections &input, VariableCo
   {
     csvJets.push_back(CSVHelper::GetJetCSV(*itJet, btagger));
   }
-  std::vector<double> csvJetsSorted = csvJets;
-  std::sort(csvJetsSorted.begin(), csvJetsSorted.end(), std::greater<double>());
-
-
-  // Tagged Jets
-  vector<float> csvTaggedJets;
-  for (std::vector<pat::Jet>::iterator itTaggedJet = selectedTaggedJets.begin(); itTaggedJet != selectedTaggedJets.end(); ++itTaggedJet)
-  {
-    csvTaggedJets.push_back(CSVHelper::GetJetCSV(*itTaggedJet, btagger));
-  }
-  sort(csvTaggedJets.begin(), csvTaggedJets.end(), std::greater<float>());
 
   // Fill Variables for closest ak4 Jets
   // All Jets

--- a/BoostedAnalyzer/src/essentialMVAVarProcessor.cpp
+++ b/BoostedAnalyzer/src/essentialMVAVarProcessor.cpp
@@ -11,59 +11,47 @@ essentialMVAVarProcessor::~essentialMVAVarProcessor()
 {
 }
 
+
+
 void essentialMVAVarProcessor::Init(const InputCollections &input, VariableContainer &vars)
 {
-  pointerToMVAvars->SetWP(CSVHelper::GetWP(input.era, CSVHelper::CSVwp::Medium, "DeepJet"));
-  // Vars from CommonClassifier:
-  map<string, float> varMap = pointerToMVAvars->GetVariables();
-  for (auto it = varMap.begin(); it != varMap.end(); it++)
-  {
-    vars.InitVar(it->first);
-  }
+    // which btagger to use
+    std::string btagger = "DeepJet";
 
-  initialized = true;
+    // set CSVWp 
+    pointerToMVAvars->SetWP(CSVHelper::GetWP(input.era, CSVHelper::CSVwp::Medium, btagger));
+
+    // initialize vars from common classifier
+    map<string, float> varMap = pointerToMVAvars->GetVariables();
+    for (auto it = varMap.begin(); it != varMap.end(); it++)
+        vars.InitVar(it->first);
+
+    initialized = true;
 }
+
+
 
 void essentialMVAVarProcessor::Process(const InputCollections &input, VariableContainer &vars)
 {
-  if (!initialized)
-    cerr << "tree processor not initialized" << endl;
+    if (!initialized) cerr << "tree processor not initialized" << endl;
 
-  // which btagger to use
-  std::string btagger = "DeepJet";
+    // btag values of jets
+    std::vector<double> csvJets;
+    for (std::vector<pat::Jet>::const_iterator itJet = input.selectedJets.begin(); itJet != input.selectedJets.end(); ++itJet)
+        csvJets.push_back(CSVHelper::GetJetCSV(*itJet, btagger));
 
-  // csv ordered jets
-  std::vector<double> csvJets;
-  for (std::vector<pat::Jet>::const_iterator itJet = input.selectedJets.begin(); itJet != input.selectedJets.end(); ++itJet)
-  {
-    csvJets.push_back(CSVHelper::GetJetCSV(*itJet, btagger));
-  }
+    // jet vecs
+    std::vector<math::XYZTLorentzVector> jetvecs = BoostedUtils::GetJetVecs(input.selectedJets);
+    vector<TLorentzVector> jetvecsTL = BoostedUtils::GetTLorentzVectors(jetvecs);
 
-  // jet vecs
-  std::vector<math::XYZTLorentzVector> jetvecs = BoostedUtils::GetJetVecs(input.selectedJets);
+    // lep vecs
+    vector<TLorentzVector> lepvecs = BoostedUtils::GetTLorentzVectors(BoostedUtils::GetLepVecs(input.selectedElectrons, input.selectedMuons));
 
-  // Ohio Variables
-  std::vector<pat::Jet> selectedJetsLooseExclusive;
-  vector<TLorentzVector> jet_loose_vecsTL;
-  vector<double> jetCSV_loose;
-  for (std::vector<pat::Jet>::const_iterator itJet = input.selectedJetsLoose.begin(); itJet != input.selectedJetsLoose.end(); ++itJet)
-  {
-    if (itJet->pt() >= 30)
-      continue;
-    selectedJetsLooseExclusive.push_back(*itJet);
-    jetCSV_loose.push_back(CSVHelper::GetJetCSV(*itJet, btagger));
-    jet_loose_vecsTL.push_back(BoostedUtils::GetTLorentzVector(itJet->p4()));
-  }
-  vector<TLorentzVector> jetvecsTL = BoostedUtils::GetTLorentzVectors(jetvecs);
+    // met vec
+    TLorentzVector metP4 = BoostedUtils::GetTLorentzVector(input.correctedMET.corP4(pat::MET::Type1XY));
   
-
-  // Variables from CommonClassifier:
-  vector<TLorentzVector> lepvecs = BoostedUtils::GetTLorentzVectors(BoostedUtils::GetLepVecs(input.selectedElectrons, input.selectedMuons));
-  TLorentzVector metP4 = BoostedUtils::GetTLorentzVector(input.correctedMET.corP4(pat::MET::Type1XY));
-
-  varMap = pointerToMVAvars->GetMVAvars(lepvecs, jetvecsTL, csvJets, metP4);
-  for (auto it = varMap.begin(); it != varMap.end(); it++)
-  {
-    vars.FillVar(it->first, it->second);
-  }
+    // fill variables from common classifier
+    varMap = pointerToMVAvars->GetMVAvars(lepvecs, jetvecsTL, csvJets, metP4);
+    for (auto it = varMap.begin(); it != varMap.end(); it++)
+        vars.FillVar(it->first, it->second);
 }

--- a/BoostedAnalyzer/src/essentialMVAVarProcessor.cpp
+++ b/BoostedAnalyzer/src/essentialMVAVarProcessor.cpp
@@ -16,7 +16,7 @@ essentialMVAVarProcessor::~essentialMVAVarProcessor()
 void essentialMVAVarProcessor::Init(const InputCollections &input, VariableContainer &vars)
 {
     // which btagger to use
-    std::string btagger = "DeepJet";
+    btagger = "DeepJet";
 
     // set CSVWp 
     pointerToMVAvars->SetWP(CSVHelper::GetWP(input.era, CSVHelper::CSVwp::Medium, btagger));

--- a/BoostedAnalyzer/src/essentialMVAVarProcessor.cpp
+++ b/BoostedAnalyzer/src/essentialMVAVarProcessor.cpp
@@ -21,15 +21,11 @@ void essentialMVAVarProcessor::Init(const InputCollections &input, VariableConta
   vars.InitVar("Evt_Eta_PrimaryLepton");
   vars.InitVar("Evt_Phi_PrimaryLepton");
 
-  vars.InitVar("Evt_M_MinDeltaRUntaggedJets");
   vars.InitVar("Evt_M_MinDeltaRLeptonTaggedJet");
   vars.InitVar("Evt_M_MinDeltaRLeptonJet");
 
-  vars.InitVar("Evt_Dr_MinDeltaRUntaggedJets");
   vars.InitVar("Evt_Dr_MinDeltaRLeptonTaggedJet");
   vars.InitVar("Evt_Dr_MinDeltaRLeptonJet");
-
-  vars.InitVar("Evt_Pt_MinDeltaRUntaggedJets");
 
   vars.InitVar("Evt_M_JetsAverage");
   vars.InitVar("Evt_M_TaggedJetsAverage");
@@ -38,12 +34,6 @@ void essentialMVAVarProcessor::Init(const InputCollections &input, VariableConta
   vars.InitVar("Evt_Eta_JetsAverage");
   vars.InitVar("Evt_Eta_TaggedJetsAverage");
   vars.InitVar("Evt_Eta_UntaggedJetsAverage");
-
-  vars.InitVar("Evt_M2_UntaggedJetsAverage");
-
-  vars.InitVar("Evt_Deta_UntaggedJetsAverage");
-
-  vars.InitVar("Evt_Dr_UntaggedJetsAverage");
 
   vars.InitVar("Evt_JetPtOverJetE");
 
@@ -109,18 +99,6 @@ void essentialMVAVarProcessor::Process(const InputCollections &input, VariableCo
   }
 
   // Fill Variables for closest ak4 Jets
-  // Untagged Jets
-  if (selectedUntaggedJets.size() > 1)
-  {
-    int idClosestUntaggedJet1 = -1;
-    int idClosestUntaggedJet2 = -1;
-    float minDrUntaggedJets = BoostedUtils::GetClosestJetIDs(idClosestUntaggedJet1, idClosestUntaggedJet2, selectedUntaggedJets);
-    math::XYZTLorentzVector closestUntaggedJetVec1 = selectedUntaggedJets[idClosestUntaggedJet1].p4();
-    math::XYZTLorentzVector closestUntaggedJetVec2 = selectedUntaggedJets[idClosestUntaggedJet2].p4();
-    vars.FillVar("Evt_M_MinDeltaRUntaggedJets", (closestUntaggedJetVec1 + closestUntaggedJetVec2).M());
-    vars.FillVar("Evt_Dr_MinDeltaRUntaggedJets", minDrUntaggedJets);
-    vars.FillVar("Evt_Pt_MinDeltaRUntaggedJets", (closestUntaggedJetVec1 + closestUntaggedJetVec2).Pt());
-  }
   // Jet and Lepton
   if (input.selectedJets.size() > 1 && (input.selectedElectrons.size() > 0 || input.selectedMuons.size() > 0))
   {
@@ -147,10 +125,6 @@ void essentialMVAVarProcessor::Process(const InputCollections &input, VariableCo
   float eJetsAverage = 0;
   float ptJetsAverage = 0;
   float etaJetsAverage = 0;
-  float m2JetsAverage = 0;
-  float detaJetsAverage = 0;
-  float drJetsAverage = 0;
-  int nPairsJets = 0;
 
   std::vector<math::XYZTLorentzVector> jetvecs = BoostedUtils::GetJetVecs(input.selectedJets);
 
@@ -160,14 +134,6 @@ void essentialMVAVarProcessor::Process(const InputCollections &input, VariableCo
     eJetsAverage += itJetVec1->E();
     ptJetsAverage += itJetVec1->Pt();
     etaJetsAverage += itJetVec1->Eta();
-
-    for (std::vector<math::XYZTLorentzVector>::iterator itJetVec2 = itJetVec1 + 1; itJetVec2 != jetvecs.end(); ++itJetVec2)
-    {
-      m2JetsAverage += (*itJetVec1 + *itJetVec2).M();
-      detaJetsAverage += fabs(itJetVec1->Eta() - itJetVec2->Eta());
-      drJetsAverage += BoostedUtils::DeltaR(*itJetVec1, *itJetVec2);
-      nPairsJets++;
-    }
   }
   if (jetvecs.size() > 0)
   {
@@ -183,7 +149,6 @@ void essentialMVAVarProcessor::Process(const InputCollections &input, VariableCo
   float etaTaggedJetsAverage = 0;
   vector<float> m2TaggedJets;
 
-  int nPairsTaggedJets = 0;
   for (std::vector<pat::Jet>::iterator itTaggedJet1 = selectedTaggedJets.begin(); itTaggedJet1 != selectedTaggedJets.end(); ++itTaggedJet1)
   {
     math::XYZTLorentzVector taggedJetVec1 = itTaggedJet1->p4();
@@ -191,13 +156,6 @@ void essentialMVAVarProcessor::Process(const InputCollections &input, VariableCo
     mTaggedJetsAverage += taggedJetVec1.M();
     etaTaggedJetsAverage += taggedJetVec1.Eta();
 
-    for (std::vector<pat::Jet>::iterator itTaggedJet2 = itTaggedJet1 + 1; itTaggedJet2 != selectedTaggedJets.end(); ++itTaggedJet2)
-    {
-      math::XYZTLorentzVector taggedJetVec2 = itTaggedJet2->p4();
-
-      m2TaggedJets.push_back((taggedJetVec1 + taggedJetVec2).M());
-      nPairsTaggedJets++;
-    }
   }
   if (selectedTaggedJets.size() > 0)
   {
@@ -214,44 +172,20 @@ void essentialMVAVarProcessor::Process(const InputCollections &input, VariableCo
   // Untagged Jets
   float mUntaggedJetsAverage = 0;
   float etaUntaggedJetsAverage = 0;
-  float m2UntaggedJetsAverage = 0;
-  float detaUntaggedJetsAverage = 0;
-  float drUntaggedJetsAverage = 0;
-  int nPairsUntaggedJets = 0;
   for (std::vector<pat::Jet>::iterator itUntaggedJet1 = selectedUntaggedJets.begin(); itUntaggedJet1 != selectedUntaggedJets.end(); ++itUntaggedJet1)
   {
     math::XYZTLorentzVector untaggedJetVec1 = itUntaggedJet1->p4();
 
     mUntaggedJetsAverage += untaggedJetVec1.M();
     etaUntaggedJetsAverage += untaggedJetVec1.Eta();
-
-    for (std::vector<pat::Jet>::iterator itUntaggedJet2 = itUntaggedJet1 + 1; itUntaggedJet2 != selectedUntaggedJets.end(); ++itUntaggedJet2)
-    {
-      math::XYZTLorentzVector untaggedJetVec2 = itUntaggedJet2->p4();
-      m2UntaggedJetsAverage += (untaggedJetVec1 + untaggedJetVec2).M();
-      detaUntaggedJetsAverage += fabs(untaggedJetVec1.Eta() - untaggedJetVec2.Eta());
-      drUntaggedJetsAverage += BoostedUtils::DeltaR(untaggedJetVec1, untaggedJetVec2);
-      //       dktUntaggedJetsAverage += BoostedUtils::DeltaKt(untaggedJetVec1,untaggedJetVec2);
-      nPairsUntaggedJets++;
-    }
   }
   if (selectedUntaggedJets.size() > 0)
   {
     mUntaggedJetsAverage /= (float)selectedUntaggedJets.size();
     etaUntaggedJetsAverage /= (float)selectedUntaggedJets.size();
   }
-  if (nPairsUntaggedJets > 0)
-  {
-    m2UntaggedJetsAverage /= nPairsUntaggedJets;
-    detaUntaggedJetsAverage /= nPairsUntaggedJets;
-    drUntaggedJetsAverage /= nPairsUntaggedJets;
-    //     dktUntaggedJetsAverage /= nPairsUntaggedJets;
-  }
   vars.FillVar("Evt_M_UntaggedJetsAverage", mUntaggedJetsAverage);
   vars.FillVar("Evt_Eta_UntaggedJetsAverage", etaUntaggedJetsAverage);
-  vars.FillVar("Evt_M2_UntaggedJetsAverage", m2UntaggedJetsAverage);
-  vars.FillVar("Evt_Deta_UntaggedJetsAverage", detaUntaggedJetsAverage);
-  vars.FillVar("Evt_Dr_UntaggedJetsAverage", drUntaggedJetsAverage);
 
   // Ohio Variables
   std::vector<pat::Jet> selectedJetsLooseExclusive;

--- a/BoostedAnalyzer/src/essentialRecoVarProcessor.cpp
+++ b/BoostedAnalyzer/src/essentialRecoVarProcessor.cpp
@@ -1,0 +1,55 @@
+#include "BoostedTTH/BoostedAnalyzer/interface/essentialRecoVarProcessor.hpp"
+
+using namespace std;
+
+essentialRecoVarProcessor::essentialRecoVarProcessor()
+{
+    pointerToRecoVars.reset(new ReconstructedVars());
+}
+
+essentialRecoVarProcessor::~essentialRecoVarProcessor() {}
+
+
+
+void essentialRecoVarProcessor::Init(const InputCollections &input, VariableContainer &vars)
+{
+    // which btagger to use
+    btagger = "DeepJet";
+
+    // set CSVWp 
+    pointerToRecoVars->SetWP(CSVHelper::GetWP(input.era, CSVHelper::CSVwp::Medium, btagger));
+
+    // initialize vars from common classifier
+    map<string, double> varMap = pointerToRecoVars->GetVariables();
+    for (auto it = varMap.begin(); it != varMap.end(); it++)
+        vars.InitVar(it->first);
+
+    initialized = true;
+}
+
+
+
+void essentialRecoVarProcessor::Process(const InputCollections &input, VariableContainer &vars)
+{
+    if (!initialized) cerr << "tree processor not initialized" << endl;
+
+    // btag values of jets
+    std::vector<double> csvJets;
+    for (std::vector<pat::Jet>::const_iterator itJet = input.selectedJets.begin(); itJet != input.selectedJets.end(); ++itJet)
+        csvJets.push_back(CSVHelper::GetJetCSV(*itJet, btagger));
+
+    // jet vecs
+    std::vector<math::XYZTLorentzVector> jetvecs = BoostedUtils::GetJetVecs(input.selectedJets);
+    vector<TLorentzVector> jetvecsTL = BoostedUtils::GetTLorentzVectors(jetvecs);
+
+    // lep vecs
+    vector<TLorentzVector> lepvecs = BoostedUtils::GetTLorentzVectors(BoostedUtils::GetLepVecs(input.selectedElectrons, input.selectedMuons));
+
+    // met vec
+    TLorentzVector metP4 = BoostedUtils::GetTLorentzVector(input.correctedMET.corP4(pat::MET::Type1XY));
+  
+    // fill variables from common classifier
+    varMap = pointerToRecoVars->GetReconstructedVars(lepvecs, jetvecsTL, csvJets, metP4);
+    for (auto it = varMap.begin(); it != varMap.end(); it++)
+        vars.FillVar(it->first, it->second);
+}

--- a/BoostedAnalyzer/test/boostedAnalysis_ntuples-Legacy_2016_2017_2018_cfg.py
+++ b/BoostedAnalyzer/test/boostedAnalysis_ntuples-Legacy_2016_2017_2018_cfg.py
@@ -632,6 +632,7 @@ if options.isData:
   "WeightProcessor",
   "essentialBasicVarProcessor",
   "essentialMVAVarProcessor",
+  "essentialRecoVarProcessor",
   "TriggerVarProcessor",
   #"ReconstructionMEvarProcessor",
   #"AK8JetProcessor"
@@ -643,6 +644,7 @@ else:
   "MCMatchVarProcessor",
   "essentialBasicVarProcessor",
   "essentialMVAVarProcessor",
+  "essentialRecoVarProcessor",
   "TriggerVarProcessor",
   #"ReconstructionMEvarProcessor",
   #"AK8JetProcessor"


### PR DESCRIPTION
variables from `essentialMVAVarProcessor` are now calculated in the `MVAvars` backend (CommonClassifier). Redundant variables were removed, naming scheme was made more homogeneous.

Reco-type variables are now processed with `essentialRecoVarProcessor` (working with `ReconstructedVars` and `Chi2Reconstruction` in the CC as backend)

The `essentialRecoVarProcessor` was added as default processor to the legacy config.

New variables for `TightLepton` and `TaggedJets` (pt ordered) were added to the `essentialBasicVarProcessor`