### PR TITLE
Chi2 Reconstruction updates + dR matching + genlevel Z boson stuff

### DIFF
--- a/BoostedAnalyzer/interface/GenTopEvent.hpp
+++ b/BoostedAnalyzer/interface/GenTopEvent.hpp
@@ -12,7 +12,9 @@ public:
     ~GenTopEvent();
 
     reco::GenParticle GetHiggs() const;
+    reco::GenParticle GetZ() const;
     std::vector<reco::GenParticle> GetHiggsDecayProducts() const;
+    std::vector<reco::GenParticle> GetZDecayProducts() const;
     bool IsFilled() const;
     bool TTxIsFilled() const;
     reco::GenParticle GetTop() const;
@@ -168,6 +170,10 @@ private:
     std::vector<reco::GenParticle> wplus_decay_products;
     std::vector<reco::GenParticle> wminus_decay_products;
     std::vector<reco::GenParticle> higgs_decay_products;
+
+    // for ttZ
+    reco::GenParticle Z;
+    std::vector<reco::GenParticle> Z_decay_products;
     
     // for THW
     reco::GenParticle w_not_from_top;
@@ -220,6 +226,7 @@ private:
     bool foundT = false;
     bool foundTbar = false;
     bool foundH = false;
+    bool foundZ = false;
     bool topIsHadronic;
     bool topbarIsHadronic;
     bool isFilled;

--- a/BoostedAnalyzer/python/Selection_cff.py
+++ b/BoostedAnalyzer/python/Selection_cff.py
@@ -80,7 +80,7 @@ DiLeptonMETSelection = cms.PSet(
 JetTagSelection = cms.PSet(
     minJets = cms.vint32(4),
     maxJets = cms.vint32(-1),
-    minTags = cms.vint32(2),
+    minTags = cms.vint32(3),
     maxTags = cms.vint32(-1)
 )
 

--- a/BoostedAnalyzer/python/Selection_cff.py
+++ b/BoostedAnalyzer/python/Selection_cff.py
@@ -80,7 +80,7 @@ DiLeptonMETSelection = cms.PSet(
 JetTagSelection = cms.PSet(
     minJets = cms.vint32(4),
     maxJets = cms.vint32(-1),
-    minTags = cms.vint32(3),
+    minTags = cms.vint32(2),
     maxTags = cms.vint32(-1)
 )
 

--- a/BoostedAnalyzer/scripts/deltaRMatcher.py
+++ b/BoostedAnalyzer/scripts/deltaRMatcher.py
@@ -1,0 +1,304 @@
+import sys
+import os
+import optparse
+import numpy as np
+import ROOT
+
+ROOT.gROOT.SetBatch(True)
+
+def draw_hist(hist, plotdir, name, label, dRlabel, ymax):
+    canvas = ROOT.TCanvas(name,name, 1024, 768)
+    canvas.SetTopMargin(0.07)
+    canvas.SetBottomMargin(0.15)
+    canvas.SetRightMargin(0.05)
+    canvas.SetLeftMargin(0.15)
+    canvas.SetTicks(1,1)
+
+    canvas.cd(1)
+
+    hist.Scale(1./hist.Integral())
+    sumHist = hist.Clone()
+    hist.SetTitle(dRlabel+"  ("+label+")")
+    hist.GetXaxis().SetTitle(name)
+    hist.GetYaxis().SetTitle("fraction of events")
+    hist.GetYaxis().SetRangeUser(0.,ymax)
+    hist.SetLineColor(ROOT.kRed)
+    hist.SetLineWidth(2)
+    #hist.SetFillColor(ROOT.kRed)
+    #hist.SetFillStyle(1001)
+    
+    hist.Draw("HIST")
+    hist.SetStats(False)
+
+    # get cumulative sum
+    integral = 0
+    for iBin in xrange(sumHist.GetNbinsX()):
+        integral += sumHist.GetBinContent(iBin+1)
+        sumHist.SetBinContent(iBin+1,integral)
+    sumHist.SetLineColor(ROOT.kBlack)
+    sumHist.SetLineWidth(1)
+    sumHist.Draw("SAME HIST")
+
+    legend=ROOT.TLegend(0.70,0.8,0.95,0.9)
+    legend.SetBorderSize(0)
+    legend.SetLineStyle(0)
+    legend.SetTextFont(42)
+    legend.SetTextSize(0.03)
+    legend.SetFillStyle(0)
+
+    legend.AddEntry(hist, name, "F")
+    legend.AddEntry(sumHist, "cumulative sum", "L")
+    legend.Draw("SAME")
+
+
+
+    canvas.SaveAs(plotdir+"/"+name+".pdf")
+    canvas.SaveAs(plotdir+"/"+name+".png")
+    canvas.Clear()
+
+class Cut:
+    types = ["==",">=","<=","<",">"]
+    def __init__(self, cutstring):
+        self.cut_type = None
+        for t in self.types:
+            if t in cutstring:
+                self.cut_type = t
+                break
+        if not self.cut_type: sys.exit("requirement {} invalid".format(cutstring))
+        split_string = cutstring.split(self.cut_type)
+        self.variable = split_string[0]
+        self.requirement = float(split_string[1])
+        print("variable {} requires to be {} {}".format(
+            self.variable, self.cut_type,self.requirement))
+
+    def getVariable(self):
+        return self.variable
+
+    def passesCut(self, value):
+        if self.cut_type == "==":
+            return value == self.requirement
+        if self.cut_type == ">=":
+            return value >= self.requirement
+        if self.cut_type == "<=":
+            return value <= self.requirement
+        if self.cut_type == "<":
+            return value < self.requirement
+        if self.cut_type == ">":
+            return value > self.requirement
+
+
+def get_dPhi(p1, p2):
+    dphi = np.abs(p1 - p2)
+    if dphi > np.pi:
+        dphi = 2.*np.pi - dphi
+    return dphi
+
+def get_dEta(e1, e2):
+    return np.abs(e1 - e2)
+
+def get_dR(p1, p2, e1, e2):
+    dphi = get_dPhi(p1, p2)
+    deta = get_dEta(e1, e2)
+    dR = np.sqrt( dphi**2 + deta**2 )
+    return dR
+
+def parse_groups(args):
+    match_groups = []
+    variable_list = []
+
+    # loop groups
+    for group in args:
+        # split conditions
+        split_group = group.split("+")
+        matches = []
+
+        # loop over match conditions
+        for match in split_group:
+            split_match = match.split("=")
+            if len(split_match) == 2:
+                variables = split_match[1]
+                name = split_match[0]
+            else:
+                variables = split_match[0]
+                name = ""
+
+            variables = variables.split(",")
+            if not len(variables) == 2:
+                sys.exit("group {} does not match the required structure.".format(group))
+            matches.append([name]+variables)
+            variable_list+=variables
+        match_groups.append(matches)
+
+    return match_groups, list(set(variable_list))
+
+def check_variables(variable_list, cuts, tree):
+    print("checking variables in tree ...")
+    for v in variable_list:
+        phi = v+"_Phi"
+        eta = v+"_Eta"
+        print("\tchecking {}".format(v))
+        if not hasattr(tree, phi):
+            sys.exit("phi variable {} not found".format(phi))
+        if not hasattr(tree, eta):
+            sys.exit("eta variable {} not found".format(eta))
+    for cut in cuts:
+        if not hasattr(tree, cut.getVariable()):
+            sys.exit("cut variable {} not found".format(cut.getVariable()))
+
+    print("variable check successfull")
+
+
+def match_events(tree, match_groups, cuts, options):
+    number_matched_events = 0
+    number_total_events = 0
+    
+    # generate some histograms to fill deltaR values
+    if options.plot:
+        hist_dict = {}
+        for group in match_groups:
+            for match in group:
+                name = match[0]
+                if not name in hist_dict:
+                    hist = ROOT.TH1F(name, name, 40, 0., 4.)
+                    hist_dict[name] = hist
+
+
+    # event loop
+    for i in xrange(tree.GetEntries()):
+        tree.GetEntry(i)
+        passesCuts = True
+        for cut in cuts:
+            if not cut.passesCut( tree.GetLeaf(cut.getVariable()).GetValue() ):
+                passesCuts = False   
+        if not passesCuts: continue
+
+        if options.verbose>1:
+            print("-"*20)
+            print("analyzing event {}".format(i))
+        number_total_events += 1
+
+        # iterate over all groups to be matched
+        all_groups_matched = True
+        one_match = False
+        tmp_hist_dict = {}
+        for group in match_groups:
+            # iterate over all neccesary matches in group
+            dRs = []
+            for match in group:
+                name = match[0]
+                phi1 = tree.GetLeaf(match[1]+"_Phi").GetValue()
+                eta1 = tree.GetLeaf(match[1]+"_Eta").GetValue()
+                phi2 = tree.GetLeaf(match[2]+"_Phi").GetValue()
+                eta2 = tree.GetLeaf(match[2]+"_Eta").GetValue()
+                # get deltaR
+                dR = get_dR(phi1, phi2, eta1, eta2)
+                if options.plot:
+                    if not name in tmp_hist_dict:
+                        tmp_hist_dict[name] = dR
+                    elif tmp_hist_dict[name] >= dR:
+                        tmp_hist_dict[name] = dR
+                dRs.append(dR)
+            if options.verbose>2:
+                print(group)
+                print(dRs)
+            
+            # check if all dRs in group match the dR requirement
+            all_matched = True
+            for dr in dRs:
+                if not dr <= options.radius:
+                    all_matched = False
+                    all_groups_matched = False
+            
+            if all_matched: 
+                if options.verbose>2: print("this group matched all dRs")
+                one_match = True
+            if options.verbose>2: print("\n")
+            
+        if options.plot:
+            for key in tmp_hist_dict:
+                hist_dict[key].Fill(tmp_hist_dict[key])
+
+        if options.matchAll:
+            if all_groups_matched:
+                if options.verbose>2: print("all groups matched all dRs")
+                number_matched_events += 1
+        else:
+            if one_match:
+                number_matched_events += 1
+
+    print("################################")
+    match_percentage = float(number_matched_events)/float(number_total_events)*100
+    print("matched {}/{} events".format(number_matched_events,number_total_events))
+    print("\t= {}%".format(match_percentage))
+    print("################################")
+
+    dRlabel = "matched {:.2f}% with \\deltaR\\leq {:.1f}".format(match_percentage, options.radius)
+    if options.plot:
+        if not os.path.exists(options.plotdir):
+            os.makedirs(options.plotdir)
+        for key in hist_dict:
+            draw_hist(hist_dict[key], options.plotdir, key, options.label, dRlabel, options.ymax)
+
+
+if __name__ == "__main__":
+
+    # option parser
+    usage = "\n\n"+"="*100+"\n"
+    usage+= "python deltaRMatcher.py -i /path/to/input/file.root -r 0.4 nameA=var1,var2+nameB=var3,var4 nameC=var5,var6\n\n"
+    usage+= "additional arguments determine the matching structure\n"
+    usage+= "two objects/variables to be deltaR matched are separated by ','\n"
+    usage+= "groups that have to be matched at the same time are appended with '+'\n"
+    usage+= "if multiple arguments are given, matches are evaluated if one of these groups is matched\n"
+    usage+= "if all groups should be matched at the same time, use the option '--all'\n\n"
+    usage+= "the variable names given as arguements are prefixes to the eta and phi variables in the root tree\n"
+    usage+= "make sure the variables of strucutre 'var_Eta' and 'var_Phi' exist in your tree\n\n"
+    usage+= "="*100
+
+    parser = optparse.OptionParser(usage=usage)
+    parser.add_option("-i","--input",dest="inputFile",default="../test/testrun_nominal_Tree.root",
+        help = "input root file. default is 'testrun_nominal_Tree.root' in test directory")
+    parser.add_option("-p","--plot",dest="plot",default=False,action="store_true",
+        help = "generate deltaR plots with names specifed in args")
+    parser.add_option("-r","--deltaR",dest="radius",default=0.4,type=float,
+        help = "matching radius")
+    parser.add_option("-c","--category",dest="cat",default="N_Jets>=6",
+        help = "requirements on some variables, e.g. N_Jets>=6,N_BTagsM>=4")
+    parser.add_option("--all",dest="matchAll",default=False,action="store_true",
+        help = "match all argument groups.")
+    parser.add_option("-v",dest="verbose",default=1,type=int,
+        help = "verbose output")
+    parser.add_option("-l","--label",dest="label",default="\\geq 6 Jets",
+        help = "label for plots")    
+    parser.add_option("-o","--plotDir",dest="plotdir",default="plots",
+        help = "directory for plots")
+    parser.add_option("-y","--ymax",dest="ymax",default=0.4,type=float,
+        help = "max value for y axis of plots")
+
+    (options, args) = parser.parse_args()
+
+    # collect groups
+    if len(args) == 0:
+        print("no matching groups were specified -- using default")
+        args = ['dR_HiggsB1=Reco_Higgs_BJet1,GenHiggs_B1+dR_HiggsB2=Reco_Higgs_BJet2,GenHiggs_B2', 'dR_HiggsB1=Reco_Higgs_BJet1,GenHiggs_B2+dR_HiggsB2=Reco_Higgs_BJet2,GenHiggs_B1']
+
+    # print all groups to be matched
+    print("matching groups:")
+    print("\n".join(args))
+
+    # parse groups
+    match_groups, variable_list = parse_groups(args)
+
+    # generate conditional cuts
+    cuts = []
+    for cut in options.cat.split(","):
+        cuts.append(Cut(cut))
+
+    # load root file
+    f = ROOT.TFile(options.inputFile)
+    tree = f.Get("MVATree")
+
+    # check if all variables exist
+    check_variables(variable_list, cuts, tree)
+
+    # match stuff
+    match_events(tree, match_groups, cuts, options)

--- a/BoostedAnalyzer/src/GenTopEvent.cpp
+++ b/BoostedAnalyzer/src/GenTopEvent.cpp
@@ -473,6 +473,7 @@ void GenTopEvent::FillTTdecay(const std::vector<reco::GenParticle>& prunedGenPar
     foundT = false;
     foundTbar = false;
     foundH = false;
+    foundZ = false;
     ttXid = ttXid_;
     // loop over all the gen particles
     for (const auto& p : prunedGenParticles) {
@@ -573,6 +574,23 @@ void GenTopEvent::FillTTdecay(const std::vector<reco::GenParticle>& prunedGenPar
                 for (uint i = 0; i < p.numberOfDaughters(); i++) {
                     if (p.pdgId() == 25 && abs(p.daughter(i)->pdgId()) != 25) {
                         higgs_decay_products.push_back(*(reco::GenParticle*)p.daughter(i));
+                    }
+                }
+            }
+        }
+        // find Z boson and its decay products
+        else if (abs(p.pdgId()) == 23) {
+            bool lastZ = true;
+            foundZ = true;
+            for (uint i = 0; i < p.numberOfDaughters(); i++) {
+                if (abs(p.daughter(i)->pdgId()) == 23)
+                    lastZ = false;
+            }
+            if (lastZ) {
+                Z = p;
+                for (uint i = 0; i < p.numberOfDaughters(); i++) {
+                    if (p.pdgId() == 23 && abs(p.daughter(i)->pdgId()) != 23) {
+                        Z_decay_products.push_back(*(reco::GenParticle*)p.daughter(i));               
                     }
                 }
             }
@@ -722,6 +740,13 @@ reco::GenParticle GenTopEvent::GetHiggs() const
     if (!isFilled)
         std::cerr << "Trying to access GenTopEvent but it is not filled" << std::endl;
     return higgs;
+}
+reco::GenParticle GenTopEvent::GetZ() const
+{
+    assert(isFilled);
+    if (!isFilled)
+        std::cerr << "Trying to access GenTopEvent but it is not filled" << std::endl;
+    return Z;
 }
 reco::GenParticle GenTopEvent::GetTop() const
 {
@@ -926,6 +951,13 @@ std::vector<reco::GenParticle> GenTopEvent::GetHiggsDecayProducts() const
     if (!isFilled)
         std::cerr << "Trying to access GenTopEvent but it is not filled" << std::endl;
     return higgs_decay_products;
+}
+std::vector<reco::GenParticle> GenTopEvent::GetZDecayProducts() const
+{
+    assert(isFilled);
+    if (!isFilled)
+        std::cerr << "Trying to access GenTopEvent but it is not filled" << std::endl;
+    return Z_decay_products;
 }
 reco::GenParticle GenTopEvent::GetTopDecayQuark() const
 {

--- a/BoostedAnalyzer/src/MCMatchVarProcessor.cpp
+++ b/BoostedAnalyzer/src/MCMatchVarProcessor.cpp
@@ -73,19 +73,19 @@ void MCMatchVarProcessor::Init(const InputCollections& input,VariableContainer& 
   vars.InitVar( "GenHiggs_B1_E",-9. );
   vars.InitVar( "GenHiggs_B2_E",-9. );
   
-  vars.InitVar( "GenZ_Pt",-9. );
-  vars.InitVar( "GenZ_Eta",-9. );
-  vars.InitVar( "GenZ_Phi",-9. );
-  vars.InitVar( "GenZ_E",-9. );
-  vars.InitVar( "GenZ_Y",-9. );
-  vars.InitVar( "GenZ_B1_Pt",-9. );
-  vars.InitVar( "GenZ_B2_Pt",-9. );
-  vars.InitVar( "GenZ_B1_Eta",-9. );
-  vars.InitVar( "GenZ_B2_Eta",-9. );
-  vars.InitVar( "GenZ_B1_Phi",-9. );
-  vars.InitVar( "GenZ_B2_Phi",-9. );
-  vars.InitVar( "GenZ_B1_E",-9. );
-  vars.InitVar( "GenZ_B2_E",-9. );
+  //vars.InitVar( "GenZ_Pt",-9. );
+  //vars.InitVar( "GenZ_Eta",-9. );
+  //vars.InitVar( "GenZ_Phi",-9. );
+  //vars.InitVar( "GenZ_E",-9. );
+  //vars.InitVar( "GenZ_Y",-9. );
+  //vars.InitVar( "GenZ_B1_Pt",-9. );
+  //vars.InitVar( "GenZ_B2_Pt",-9. );
+  //vars.InitVar( "GenZ_B1_Eta",-9. );
+  //vars.InitVar( "GenZ_B2_Eta",-9. );
+  //vars.InitVar( "GenZ_B1_Phi",-9. );
+  //vars.InitVar( "GenZ_B2_Phi",-9. );
+  //vars.InitVar( "GenZ_B1_E",-9. );
+  //vars.InitVar( "GenZ_B2_E",-9. );
 
 
 
@@ -95,8 +95,8 @@ void MCMatchVarProcessor::Init(const InputCollections& input,VariableContainer& 
   vars.InitVars( "GenTopLep_B_Idx",-1,"N_GenTopLep" );
   vars.InitVar( "GenHiggs_B1_Idx",-1 );
   vars.InitVar( "GenHiggs_B2_Idx",-1 );
-  vars.InitVar( "GenZ_B1_Idx",-1 );
-  vars.InitVar( "GenZ_B2_Idx",-1 );
+  //vars.InitVar( "GenZ_B1_Idx",-1 );
+  //vars.InitVar( "GenZ_B2_Idx",-1 );
   
   vars.InitVar( "GenHiggs_DecProd1_Pt",-9. );
   vars.InitVar( "GenHiggs_DecProd1_Eta",-9. );
@@ -144,31 +144,31 @@ void MCMatchVarProcessor::Init(const InputCollections& input,VariableContainer& 
   vars.InitVars( "GenTopLep_B_Hadron_E",-9., "N_GenTopLep" );
   vars.InitVars( "GenTopHad_B_Hadron_E",-9., "N_GenTopHad");
   
-  //// for THW
-  //vars.InitVar( "GenW_NotFromTop_Pt",-9. );
-  //vars.InitVar( "GenW_NotFromTop_Eta",-9. );
-  //vars.InitVar( "GenW_NotFromTop_Phi",-9. );
-  //vars.InitVar( "GenW_NotFromTop_E",-9. );
-  //vars.InitVar( "N_GenW_NotFromTop_DecProds",-1,"I" );
-  //vars.InitVars( "GenW_NotFromTop_DecProd_Pt",-9., "N_GenW_NotFromTop_DecProds" );
-  //vars.InitVars( "GenW_NotFromTop_DecProd_Eta",-9., "N_GenW_NotFromTop_DecProds" );
-  //vars.InitVars( "GenW_NotFromTop_DecProd_Phi",-9., "N_GenW_NotFromTop_DecProds" );
-  //vars.InitVars( "GenW_NotFromTop_DecProd_E",-9., "N_GenW_NotFromTop_DecProds" );
-  //vars.InitVars( "GenW_NotFromTop_DecProd_PDGID",-999, "N_GenW_NotFromTop_DecProds" );
-  //
-  //// for THQ
-  //vars.InitVar( "GenForwardQuark_Pt",-9. );
-  //vars.InitVar( "GenForwardQuark_Eta",-9. );
-  //vars.InitVar( "GenForwardQuark_Phi",-9. );
-  //vars.InitVar( "GenForwardQuark_E",-9. );
-  //vars.InitVar( "GenForwardQuark_PDGID",-999 );
+  // for THW
+  vars.InitVar( "GenW_NotFromTop_Pt",-9. );
+  vars.InitVar( "GenW_NotFromTop_Eta",-9. );
+  vars.InitVar( "GenW_NotFromTop_Phi",-9. );
+  vars.InitVar( "GenW_NotFromTop_E",-9. );
+  vars.InitVar( "N_GenW_NotFromTop_DecProds",-1,"I" );
+  vars.InitVars( "GenW_NotFromTop_DecProd_Pt",-9., "N_GenW_NotFromTop_DecProds" );
+  vars.InitVars( "GenW_NotFromTop_DecProd_Eta",-9., "N_GenW_NotFromTop_DecProds" );
+  vars.InitVars( "GenW_NotFromTop_DecProd_Phi",-9., "N_GenW_NotFromTop_DecProds" );
+  vars.InitVars( "GenW_NotFromTop_DecProd_E",-9., "N_GenW_NotFromTop_DecProds" );
+  vars.InitVars( "GenW_NotFromTop_DecProd_PDGID",-999, "N_GenW_NotFromTop_DecProds" );
+  
+  // for THQ
+  vars.InitVar( "GenForwardQuark_Pt",-9. );
+  vars.InitVar( "GenForwardQuark_Eta",-9. );
+  vars.InitVar( "GenForwardQuark_Phi",-9. );
+  vars.InitVar( "GenForwardQuark_E",-9. );
+  vars.InitVar( "GenForwardQuark_PDGID",-999 );
 
 
-  //// for ttbar dR matching
-  vars.InitVar("Gen_ttbar_matched", 0, "I");
-  vars.InitVar("Gen_ttH_matched", 0, "I");
+  // for ttbar dR matching
+  //vars.InitVar("Gen_ttbar_matched", 0, "I");
+  //vars.InitVar("Gen_ttH_matched", 0, "I");
   vars.InitVar("GenHiggsMassFromMatchedJets",-9.);
-  vars.InitVar("GenZMassFromMatchedJets",-9.);
+  //vars.InitVar("GenZMassFromMatchedJets",-9.);
   vars.InitVars("GenHadTopMassFromMatchedJets",-9.,"N_GenTopHad");
   vars.InitVars("GenHadWMassFromMatchedJets",-9.,"N_GenTopHad");
   initialized = true;
@@ -458,59 +458,59 @@ void MCMatchVarProcessor::Process(const InputCollections& input,VariableContaine
 
 
   // fill Z system
-  if(Z.pt()>0.){
-    vars.FillVar( "GenZ_Pt",Z.pt());
-    vars.FillVar( "GenZ_Eta",Z.eta());
-    vars.FillVar( "GenZ_Phi",Z.phi());
-    vars.FillVar( "GenZ_E",Z.energy());
-    vars.FillVar( "GenZ_Y",Z.rapidity());
-  }
-  if(Zb1.pt()>0.){
-    vars.FillVar("GenZ_B1_Pt",Zb1.pt());
-    vars.FillVar("GenZ_B2_Pt",Zb2.pt());
-    vars.FillVar("GenZ_B1_Eta",Zb1.eta());
-    vars.FillVar("GenZ_B2_Eta",Zb2.eta());
-    vars.FillVar("GenZ_B1_Phi",Zb1.phi());
-    vars.FillVar("GenZ_B2_Phi",Zb2.phi());
-    vars.FillVar("GenZ_B1_E",Zb1.energy());
-    vars.FillVar("GenZ_B2_E",Zb2.energy());
-    
-    int idxb1=-1;
-    int idxb2=-1;
-    
-    double minDrB1 = 999;
-    double minDrB2 = 999;
-    
-    for(std::vector<math::XYZTLorentzVector>::iterator itJetVec = jetvecs.begin() ; itJetVec != jetvecs.end(); ++itJetVec){
-      assert(itJetVec->pt()>0);
-      assert(Zb1.pt()>0);
-      assert(Zb2.pt()>0);
-      if(BoostedUtils::DeltaR(*itJetVec,Zb1.p4())<minDrB1){
-        idxb1 = itJetVec-jetvecs.begin();
-        minDrB1 = BoostedUtils::DeltaR(*itJetVec,Zb1.p4());
-      }
-      if(BoostedUtils::DeltaR(*itJetVec,Zb2.p4())<minDrB2){
-        idxb2 = itJetVec-jetvecs.begin();
-        minDrB2 = BoostedUtils::DeltaR(*itJetVec,Zb2.p4());
-      }
-    }
-    
-    if(minDrB1<.25){
-      vars.FillVar( "GenZ_B1_Idx",idxb1);
-    }
-    if(minDrB2<.25){
-      vars.FillVar( "GenZ_B2_Idx",idxb2);
-    }
-
-    // get mass of dijet system of B indices were found
-    if( minDrB1<.25 && minDrB2<.25 )
-    {
-        // get dijet
-        math::XYZTLorentzVector Z_vec = jetvecs[idxb1]+jetvecs[idxb2];
-        vars.FillVar("GenZMassFromMatchedJets", Z_vec.M());
-    }
-
-  }
+  //if(Z.pt()>0.){
+  //  vars.FillVar( "GenZ_Pt",Z.pt());
+  //  vars.FillVar( "GenZ_Eta",Z.eta());
+  //  vars.FillVar( "GenZ_Phi",Z.phi());
+  //  vars.FillVar( "GenZ_E",Z.energy());
+  //  vars.FillVar( "GenZ_Y",Z.rapidity());
+  //}
+  //if(Zb1.pt()>0.){
+  //  vars.FillVar("GenZ_B1_Pt",Zb1.pt());
+  //  vars.FillVar("GenZ_B2_Pt",Zb2.pt());
+  //  vars.FillVar("GenZ_B1_Eta",Zb1.eta());
+  //  vars.FillVar("GenZ_B2_Eta",Zb2.eta());
+  //  vars.FillVar("GenZ_B1_Phi",Zb1.phi());
+  //  vars.FillVar("GenZ_B2_Phi",Zb2.phi());
+  //  vars.FillVar("GenZ_B1_E",Zb1.energy());
+  //  vars.FillVar("GenZ_B2_E",Zb2.energy());
+  //  
+  //  int idxb1=-1;
+  //  int idxb2=-1;
+  //  
+  //  double minDrB1 = 999;
+  //  double minDrB2 = 999;
+  //  
+  //  for(std::vector<math::XYZTLorentzVector>::iterator itJetVec = jetvecs.begin() ; itJetVec != jetvecs.end(); ++itJetVec){
+  //    assert(itJetVec->pt()>0);
+  //    assert(Zb1.pt()>0);
+  //    assert(Zb2.pt()>0);
+  //    if(BoostedUtils::DeltaR(*itJetVec,Zb1.p4())<minDrB1){
+  //      idxb1 = itJetVec-jetvecs.begin();
+  //      minDrB1 = BoostedUtils::DeltaR(*itJetVec,Zb1.p4());
+  //    }
+  //    if(BoostedUtils::DeltaR(*itJetVec,Zb2.p4())<minDrB2){
+  //      idxb2 = itJetVec-jetvecs.begin();
+  //      minDrB2 = BoostedUtils::DeltaR(*itJetVec,Zb2.p4());
+  //    }
+  //  }
+  //  
+  //  if(minDrB1<.25){
+  //    vars.FillVar( "GenZ_B1_Idx",idxb1);
+  //  }
+  //  if(minDrB2<.25){
+  //    vars.FillVar( "GenZ_B2_Idx",idxb2);
+  //  }
+  //
+  //  // get mass of dijet system of B indices were found
+  //  if( minDrB1<.25 && minDrB2<.25 )
+  //  {
+  //      // get dijet
+  //      math::XYZTLorentzVector Z_vec = jetvecs[idxb1]+jetvecs[idxb2];
+  //      vars.FillVar("GenZMassFromMatchedJets", Z_vec.M());
+  //  }
+  //
+  //}
 
 
   // fill semileptonic gen top event stuff
@@ -574,130 +574,131 @@ void MCMatchVarProcessor::Process(const InputCollections& input,VariableContaine
     }
   }
   
-  //// for THW
-  //if(w_not_from_top.pt()>0.){
-  //  vars.FillVar( "GenW_NotFromTop_Pt",w_not_from_top.pt());
-  //  vars.FillVar( "GenW_NotFromTop_Eta",w_not_from_top.eta());
-  //  vars.FillVar( "GenW_NotFromTop_Phi",w_not_from_top.phi());
-  //  vars.FillVar( "GenW_NotFromTop_E",w_not_from_top.energy());
-  //}
-  //vars.FillVar( "N_GenW_NotFromTop_DecProds",w_not_from_top_decay_products.size() );
-  //for(size_t i=0;i<w_not_from_top_decay_products.size();i++){
-  //  vars.FillVars("GenW_NotFromTop_DecProd_Pt",i,w_not_from_top_decay_products.at(i).pt() );
-  //  vars.FillVars("GenW_NotFromTop_DecProd_Eta",i,w_not_from_top_decay_products.at(i).eta() );
-  //  vars.FillVars("GenW_NotFromTop_DecProd_Phi",i,w_not_from_top_decay_products.at(i).phi() );
-  //  vars.FillVars("GenW_NotFromTop_DecProd_E",i,w_not_from_top_decay_products.at(i).energy() );
-  //  vars.FillVars("GenW_NotFromTop_DecProd_PDGID",i,w_not_from_top_decay_products.at(i).pdgId() );
-  //}
-  //
-  //// for THQ
-  //if(forward_quark.pt()>0.){
-  //  vars.FillVar( "GenForwardQuark_Pt",forward_quark.pt());
-  //  vars.FillVar( "GenForwardQuark_Eta",forward_quark.eta());
-  //  vars.FillVar( "GenForwardQuark_Phi",forward_quark.phi());
-  //  vars.FillVar( "GenForwardQuark_E",forward_quark.energy());
-  //  vars.FillVar( "GenForwardQuark_PDGID",forward_quark.pdgId());
-  //}
+  // for THW
+  if(w_not_from_top.pt()>0.){
+    vars.FillVar( "GenW_NotFromTop_Pt",w_not_from_top.pt());
+    vars.FillVar( "GenW_NotFromTop_Eta",w_not_from_top.eta());
+    vars.FillVar( "GenW_NotFromTop_Phi",w_not_from_top.phi());
+    vars.FillVar( "GenW_NotFromTop_E",w_not_from_top.energy());
+  }
+  vars.FillVar( "N_GenW_NotFromTop_DecProds",w_not_from_top_decay_products.size() );
+  for(size_t i=0;i<w_not_from_top_decay_products.size();i++){
+    vars.FillVars("GenW_NotFromTop_DecProd_Pt",i,w_not_from_top_decay_products.at(i).pt() );
+    vars.FillVars("GenW_NotFromTop_DecProd_Eta",i,w_not_from_top_decay_products.at(i).eta() );
+    vars.FillVars("GenW_NotFromTop_DecProd_Phi",i,w_not_from_top_decay_products.at(i).phi() );
+    vars.FillVars("GenW_NotFromTop_DecProd_E",i,w_not_from_top_decay_products.at(i).energy() );
+    vars.FillVars("GenW_NotFromTop_DecProd_PDGID",i,w_not_from_top_decay_products.at(i).pdgId() );
+  }
+  
+  // for THQ
+  if(forward_quark.pt()>0.){
+    vars.FillVar( "GenForwardQuark_Pt",forward_quark.pt());
+    vars.FillVar( "GenForwardQuark_Eta",forward_quark.eta());
+    vars.FillVar( "GenForwardQuark_Phi",forward_quark.phi());
+    vars.FillVar( "GenForwardQuark_E",forward_quark.energy());
+    vars.FillVar( "GenForwardQuark_PDGID",forward_quark.pdgId());
+  }
 
-    if(input.genTopEvt.IsFilled()&&input.genTopEvt.TTxIsFilled()&&input.genTopEvt.IsSemiLepton()) {
 
-        double dR_bhad;
-        double dR_blep;
-        double dR_q1;
-        double dR_q2;
+    //if(input.genTopEvt.IsFilled()&&input.genTopEvt.TTxIsFilled()&&input.genTopEvt.IsSemiLepton()) {
 
-        double dR_b1;
-        double dR_b2;
-        bool found_ttbar = false;
-        bool found_ttH = false;
-        double dR_threshold_match = 0.5;
-        int it_i, it_j, it_k, it_l, it_m, it_n;
+    //    double dR_bhad;
+    //    double dR_blep;
+    //    double dR_q1;
+    //    double dR_q2;
 
-        it_i = 0;
-        for( auto i = input.selectedJets.begin(); i!=input.selectedJets.end(); i++ )
-        {   
-            if(found_ttH) break;
-            it_i++;
+    //    double dR_b1;
+    //    double dR_b2;
+    //    bool found_ttbar = false;
+    //    bool found_ttH = false;
+    //    double dR_threshold_match = 0.5;
+    //    int it_i, it_j, it_k, it_l, it_m, it_n;
 
-            if (!CSVHelper::PassesCSV(*i, "DeepJet", CSVHelper::CSVwp::Medium,input.era)) continue;
-            // search for a dR that matches the hadronic b
-            dR_bhad = std::abs(BoostedUtils::DeltaR(i->p4(), bhad[0].p4()));
-            if (dR_bhad > dR_threshold_match) continue;
+    //    it_i = 0;
+    //    for( auto i = input.selectedJets.begin(); i!=input.selectedJets.end(); i++ )
+    //    {   
+    //        if(found_ttH) break;
+    //        it_i++;
 
-            it_j = 0;
-            for( auto j = input.selectedJets.begin(); j!=input.selectedJets.end(); j++ )
-            {
-                if(found_ttH) break;
-                it_j++;
-                if(it_i==it_j) continue;
+    //        if (!CSVHelper::PassesCSV(*i, "DeepJet", CSVHelper::CSVwp::Medium,input.era)) continue;
+    //        // search for a dR that matches the hadronic b
+    //        dR_bhad = std::abs(BoostedUtils::DeltaR(i->p4(), bhad[0].p4()));
+    //        if (dR_bhad > dR_threshold_match) continue;
 
-                if (!CSVHelper::PassesCSV(*j, "DeepJet", CSVHelper::CSVwp::Medium,input.era)) continue;
-                // search for a dR that matches the leptonic b
-                dR_blep = std::abs(BoostedUtils::DeltaR(j->p4(), blep[0].p4()));
-                if( dR_blep > dR_threshold_match) continue;
+    //        it_j = 0;
+    //        for( auto j = input.selectedJets.begin(); j!=input.selectedJets.end(); j++ )
+    //        {
+    //            if(found_ttH) break;
+    //            it_j++;
+    //            if(it_i==it_j) continue;
 
-                it_k = 0;
-                for( auto k = input.selectedJets.begin(); k!=input.selectedJets.end(); k++ )
-                {
-                    if(found_ttH) break;
-                    it_k++;
-                    if(it_k==it_i || it_k==it_j) continue;
+    //            if (!CSVHelper::PassesCSV(*j, "DeepJet", CSVHelper::CSVwp::Medium,input.era)) continue;
+    //            // search for a dR that matches the leptonic b
+    //            dR_blep = std::abs(BoostedUtils::DeltaR(j->p4(), blep[0].p4()));
+    //            if( dR_blep > dR_threshold_match) continue;
 
-                    // search for first hadronic W jet
-                    dR_q1 = std::abs(BoostedUtils::DeltaR(k->p4(), q1[0].p4()));
-                    if( dR_q1 > dR_threshold_match) continue;
+    //            it_k = 0;
+    //            for( auto k = input.selectedJets.begin(); k!=input.selectedJets.end(); k++ )
+    //            {
+    //                if(found_ttH) break;
+    //                it_k++;
+    //                if(it_k==it_i || it_k==it_j) continue;
 
-                    it_l = 0;
-                    for( auto l = input.selectedJets.begin(); l!=input.selectedJets.end(); l++ )
-                    {
-                        if(found_ttH) break;
-                        it_l++;
-                        if(it_l==it_i||it_l==it_j||it_l==it_k) continue;
+    //                // search for first hadronic W jet
+    //                dR_q1 = std::abs(BoostedUtils::DeltaR(k->p4(), q1[0].p4()));
+    //                if( dR_q1 > dR_threshold_match) continue;
 
-                        // search for second hadronic W jet
-                        dR_q2 = std::abs(BoostedUtils::DeltaR(l->p4(), q2[0].p4()));
-                        if( dR_q2 > dR_threshold_match) continue;
+    //                it_l = 0;
+    //                for( auto l = input.selectedJets.begin(); l!=input.selectedJets.end(); l++ )
+    //                {
+    //                    if(found_ttH) break;
+    //                    it_l++;
+    //                    if(it_l==it_i||it_l==it_j||it_l==it_k) continue;
 
-                        // successfully found ttbar config
-                        found_ttbar = true;
+    //                    // search for second hadronic W jet
+    //                    dR_q2 = std::abs(BoostedUtils::DeltaR(l->p4(), q2[0].p4()));
+    //                    if( dR_q2 > dR_threshold_match) continue;
 
-                        it_m = 0;
-                        for( auto m = input.selectedJets.begin(); m!=input.selectedJets.end(); m++ )
-                        {
-                            if(found_ttH) break;
-                            it_m++;
-                            if(it_m==it_i||it_m==it_j||it_m==it_k||it_m==it_l) continue;
+    //                    // successfully found ttbar config
+    //                    found_ttbar = true;
 
-                            //if (!CSVHelper::PassesCSV(*m, "DeepJet", CSVHelper::CSVwp::Medium,input.era)) continue;
-                            // search for first higgs b
-                            dR_b1 = std::abs(BoostedUtils::DeltaR(m->p4(), b1.p4()));
-                            if( dR_b1 > dR_threshold_match) continue;
+    //                    it_m = 0;
+    //                    for( auto m = input.selectedJets.begin(); m!=input.selectedJets.end(); m++ )
+    //                    {
+    //                        if(found_ttH) break;
+    //                        it_m++;
+    //                        if(it_m==it_i||it_m==it_j||it_m==it_k||it_m==it_l) continue;
 
-                            it_n = 0;
-                            for( auto n = input.selectedJets.begin(); n!=input.selectedJets.end(); n++ )
-                            {
-                                if(found_ttH) break;
-                                it_n++;
-                                if(it_n==it_i||it_n==it_j||it_n==it_k||it_n==it_l||it_n==it_m) continue;
+    //                        //if (!CSVHelper::PassesCSV(*m, "DeepJet", CSVHelper::CSVwp::Medium,input.era)) continue;
+    //                        // search for first higgs b
+    //                        dR_b1 = std::abs(BoostedUtils::DeltaR(m->p4(), b1.p4()));
+    //                        if( dR_b1 > dR_threshold_match) continue;
 
-                                //if (!CSVHelper::PassesCSV(*n, "DeepJet", CSVHelper::CSVwp::Medium,input.era)) continue;
-                                // search for first higgs b
-                                dR_b2 = std::abs(BoostedUtils::DeltaR(n->p4(), b2.p4()));
-                                if( dR_b2 > dR_threshold_match) continue;
+    //                        it_n = 0;
+    //                        for( auto n = input.selectedJets.begin(); n!=input.selectedJets.end(); n++ )
+    //                        {
+    //                            if(found_ttH) break;
+    //                            it_n++;
+    //                            if(it_n==it_i||it_n==it_j||it_n==it_k||it_n==it_l||it_n==it_m) continue;
 
-                                // successfully found ttH config
-                                found_ttH = true;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        if (found_ttbar) 
-            vars.FillVar("Gen_ttbar_matched", 1);
-        if (found_ttH)   
-            vars.FillVar("Gen_ttH_matched", 1);
+    //                            //if (!CSVHelper::PassesCSV(*n, "DeepJet", CSVHelper::CSVwp::Medium,input.era)) continue;
+    //                            // search for first higgs b
+    //                            dR_b2 = std::abs(BoostedUtils::DeltaR(n->p4(), b2.p4()));
+    //                            if( dR_b2 > dR_threshold_match) continue;
 
-    }
+    //                            // successfully found ttH config
+    //                            found_ttH = true;
+    //                        }
+    //                    }
+    //                }
+    //            }
+    //        }
+    //    }
+    //    if (found_ttbar) 
+    //        vars.FillVar("Gen_ttbar_matched", 1);
+    //    if (found_ttH)   
+    //        vars.FillVar("Gen_ttH_matched", 1);
+
+    //}
 
 }

--- a/BoostedAnalyzer/src/MCMatchVarProcessor.cpp
+++ b/BoostedAnalyzer/src/MCMatchVarProcessor.cpp
@@ -144,27 +144,27 @@ void MCMatchVarProcessor::Init(const InputCollections& input,VariableContainer& 
   vars.InitVars( "GenTopLep_B_Hadron_E",-9., "N_GenTopLep" );
   vars.InitVars( "GenTopHad_B_Hadron_E",-9., "N_GenTopHad");
   
-  // for THW
-  vars.InitVar( "GenW_NotFromTop_Pt",-9. );
-  vars.InitVar( "GenW_NotFromTop_Eta",-9. );
-  vars.InitVar( "GenW_NotFromTop_Phi",-9. );
-  vars.InitVar( "GenW_NotFromTop_E",-9. );
-  vars.InitVar( "N_GenW_NotFromTop_DecProds",-1,"I" );
-  vars.InitVars( "GenW_NotFromTop_DecProd_Pt",-9., "N_GenW_NotFromTop_DecProds" );
-  vars.InitVars( "GenW_NotFromTop_DecProd_Eta",-9., "N_GenW_NotFromTop_DecProds" );
-  vars.InitVars( "GenW_NotFromTop_DecProd_Phi",-9., "N_GenW_NotFromTop_DecProds" );
-  vars.InitVars( "GenW_NotFromTop_DecProd_E",-9., "N_GenW_NotFromTop_DecProds" );
-  vars.InitVars( "GenW_NotFromTop_DecProd_PDGID",-999, "N_GenW_NotFromTop_DecProds" );
-  
-  // for THQ
-  vars.InitVar( "GenForwardQuark_Pt",-9. );
-  vars.InitVar( "GenForwardQuark_Eta",-9. );
-  vars.InitVar( "GenForwardQuark_Phi",-9. );
-  vars.InitVar( "GenForwardQuark_E",-9. );
-  vars.InitVar( "GenForwardQuark_PDGID",-999 );
+  //// for THW
+  //vars.InitVar( "GenW_NotFromTop_Pt",-9. );
+  //vars.InitVar( "GenW_NotFromTop_Eta",-9. );
+  //vars.InitVar( "GenW_NotFromTop_Phi",-9. );
+  //vars.InitVar( "GenW_NotFromTop_E",-9. );
+  //vars.InitVar( "N_GenW_NotFromTop_DecProds",-1,"I" );
+  //vars.InitVars( "GenW_NotFromTop_DecProd_Pt",-9., "N_GenW_NotFromTop_DecProds" );
+  //vars.InitVars( "GenW_NotFromTop_DecProd_Eta",-9., "N_GenW_NotFromTop_DecProds" );
+  //vars.InitVars( "GenW_NotFromTop_DecProd_Phi",-9., "N_GenW_NotFromTop_DecProds" );
+  //vars.InitVars( "GenW_NotFromTop_DecProd_E",-9., "N_GenW_NotFromTop_DecProds" );
+  //vars.InitVars( "GenW_NotFromTop_DecProd_PDGID",-999, "N_GenW_NotFromTop_DecProds" );
+  //
+  //// for THQ
+  //vars.InitVar( "GenForwardQuark_Pt",-9. );
+  //vars.InitVar( "GenForwardQuark_Eta",-9. );
+  //vars.InitVar( "GenForwardQuark_Phi",-9. );
+  //vars.InitVar( "GenForwardQuark_E",-9. );
+  //vars.InitVar( "GenForwardQuark_PDGID",-999 );
 
 
-  // for ttbar dR matching
+  //// for ttbar dR matching
   vars.InitVar("Gen_ttbar_matched", 0, "I");
   vars.InitVar("Gen_ttH_matched", 0, "I");
   vars.InitVar("GenHiggsMassFromMatchedJets",-9.);
@@ -574,30 +574,30 @@ void MCMatchVarProcessor::Process(const InputCollections& input,VariableContaine
     }
   }
   
-  // for THW
-  if(w_not_from_top.pt()>0.){
-    vars.FillVar( "GenW_NotFromTop_Pt",w_not_from_top.pt());
-    vars.FillVar( "GenW_NotFromTop_Eta",w_not_from_top.eta());
-    vars.FillVar( "GenW_NotFromTop_Phi",w_not_from_top.phi());
-    vars.FillVar( "GenW_NotFromTop_E",w_not_from_top.energy());
-  }
-  vars.FillVar( "N_GenW_NotFromTop_DecProds",w_not_from_top_decay_products.size() );
-  for(size_t i=0;i<w_not_from_top_decay_products.size();i++){
-    vars.FillVars("GenW_NotFromTop_DecProd_Pt",i,w_not_from_top_decay_products.at(i).pt() );
-    vars.FillVars("GenW_NotFromTop_DecProd_Eta",i,w_not_from_top_decay_products.at(i).eta() );
-    vars.FillVars("GenW_NotFromTop_DecProd_Phi",i,w_not_from_top_decay_products.at(i).phi() );
-    vars.FillVars("GenW_NotFromTop_DecProd_E",i,w_not_from_top_decay_products.at(i).energy() );
-    vars.FillVars("GenW_NotFromTop_DecProd_PDGID",i,w_not_from_top_decay_products.at(i).pdgId() );
-  }
-  
-  // for THQ
-  if(forward_quark.pt()>0.){
-    vars.FillVar( "GenForwardQuark_Pt",forward_quark.pt());
-    vars.FillVar( "GenForwardQuark_Eta",forward_quark.eta());
-    vars.FillVar( "GenForwardQuark_Phi",forward_quark.phi());
-    vars.FillVar( "GenForwardQuark_E",forward_quark.energy());
-    vars.FillVar( "GenForwardQuark_PDGID",forward_quark.pdgId());
-  }
+  //// for THW
+  //if(w_not_from_top.pt()>0.){
+  //  vars.FillVar( "GenW_NotFromTop_Pt",w_not_from_top.pt());
+  //  vars.FillVar( "GenW_NotFromTop_Eta",w_not_from_top.eta());
+  //  vars.FillVar( "GenW_NotFromTop_Phi",w_not_from_top.phi());
+  //  vars.FillVar( "GenW_NotFromTop_E",w_not_from_top.energy());
+  //}
+  //vars.FillVar( "N_GenW_NotFromTop_DecProds",w_not_from_top_decay_products.size() );
+  //for(size_t i=0;i<w_not_from_top_decay_products.size();i++){
+  //  vars.FillVars("GenW_NotFromTop_DecProd_Pt",i,w_not_from_top_decay_products.at(i).pt() );
+  //  vars.FillVars("GenW_NotFromTop_DecProd_Eta",i,w_not_from_top_decay_products.at(i).eta() );
+  //  vars.FillVars("GenW_NotFromTop_DecProd_Phi",i,w_not_from_top_decay_products.at(i).phi() );
+  //  vars.FillVars("GenW_NotFromTop_DecProd_E",i,w_not_from_top_decay_products.at(i).energy() );
+  //  vars.FillVars("GenW_NotFromTop_DecProd_PDGID",i,w_not_from_top_decay_products.at(i).pdgId() );
+  //}
+  //
+  //// for THQ
+  //if(forward_quark.pt()>0.){
+  //  vars.FillVar( "GenForwardQuark_Pt",forward_quark.pt());
+  //  vars.FillVar( "GenForwardQuark_Eta",forward_quark.eta());
+  //  vars.FillVar( "GenForwardQuark_Phi",forward_quark.phi());
+  //  vars.FillVar( "GenForwardQuark_E",forward_quark.energy());
+  //  vars.FillVar( "GenForwardQuark_PDGID",forward_quark.pdgId());
+  //}
 
     if(input.genTopEvt.IsFilled()&&input.genTopEvt.TTxIsFilled()&&input.genTopEvt.IsSemiLepton()) {
 

--- a/BoostedAnalyzer/src/MCMatchVarProcessor.cpp
+++ b/BoostedAnalyzer/src/MCMatchVarProcessor.cpp
@@ -73,12 +73,30 @@ void MCMatchVarProcessor::Init(const InputCollections& input,VariableContainer& 
   vars.InitVar( "GenHiggs_B1_E",-9. );
   vars.InitVar( "GenHiggs_B2_E",-9. );
   
+  vars.InitVar( "GenZ_Pt",-9. );
+  vars.InitVar( "GenZ_Eta",-9. );
+  vars.InitVar( "GenZ_Phi",-9. );
+  vars.InitVar( "GenZ_E",-9. );
+  vars.InitVar( "GenZ_Y",-9. );
+  vars.InitVar( "GenZ_B1_Pt",-9. );
+  vars.InitVar( "GenZ_B2_Pt",-9. );
+  vars.InitVar( "GenZ_B1_Eta",-9. );
+  vars.InitVar( "GenZ_B2_Eta",-9. );
+  vars.InitVar( "GenZ_B1_Phi",-9. );
+  vars.InitVar( "GenZ_B2_Phi",-9. );
+  vars.InitVar( "GenZ_B1_E",-9. );
+  vars.InitVar( "GenZ_B2_E",-9. );
+
+
+
   vars.InitVars( "GenTopHad_B_Idx",-1,"N_GenTopHad" );
   vars.InitVars( "GenTopHad_Q1_Idx",-1,"N_GenTopHad" );
   vars.InitVars( "GenTopHad_Q2_Idx",-1,"N_GenTopHad" );
   vars.InitVars( "GenTopLep_B_Idx",-1,"N_GenTopLep" );
   vars.InitVar( "GenHiggs_B1_Idx",-1 );
   vars.InitVar( "GenHiggs_B2_Idx",-1 );
+  vars.InitVar( "GenZ_B1_Idx",-1 );
+  vars.InitVar( "GenZ_B2_Idx",-1 );
   
   vars.InitVar( "GenHiggs_DecProd1_Pt",-9. );
   vars.InitVar( "GenHiggs_DecProd1_Eta",-9. );
@@ -149,6 +167,10 @@ void MCMatchVarProcessor::Init(const InputCollections& input,VariableContainer& 
   // for ttbar dR matching
   vars.InitVar("Gen_ttbar_matched", 0, "I");
   vars.InitVar("Gen_ttH_matched", 0, "I");
+  vars.InitVar("GenHiggsMassFromMatchedJets",-9.);
+  vars.InitVar("GenZMassFromMatchedJets",-9.);
+  vars.InitVars("GenHadTopMassFromMatchedJets",-9.,"N_GenTopHad");
+  vars.InitVars("GenHadWMassFromMatchedJets",-9.,"N_GenTopHad");
   initialized = true;
 }
 
@@ -192,12 +214,15 @@ void MCMatchVarProcessor::Process(const InputCollections& input,VariableContaine
   std::vector<reco::GenParticle> lep;
   std::vector<reco::GenParticle> nu;
   reco::GenParticle higgs;
+  // for ttZ
+  reco::GenParticle Z;
   // for THW
   reco::GenParticle w_not_from_top;
   std::vector<reco::GenParticle> w_not_from_top_decay_products;
   // for THQ
   reco::GenParticle forward_quark;
   std::vector<reco::GenParticle> higgs_bs;
+  std::vector<reco::GenParticle> Z_bs;
   if(input.genTopEvt.IsFilled()){
     tophad=input.genTopEvt.GetAllTopHads();
     whad=input.genTopEvt.GetAllWhads();
@@ -211,6 +236,9 @@ void MCMatchVarProcessor::Process(const InputCollections& input,VariableContaine
     nu=input.genTopEvt.GetAllNeutrinos();
     higgs=input.genTopEvt.GetHiggs();
     higgs_bs=input.genTopEvt.GetHiggsDecayProducts();
+    Z_bs=input.genTopEvt.GetZDecayProducts();
+    // for ttZ
+    Z = input.genTopEvt.GetZ();
     // for THW
     w_not_from_top = input.genTopEvt.GetWNotFromTop();
     w_not_from_top_decay_products = input.genTopEvt.GetWNotFromTopDecayProducts();
@@ -220,11 +248,13 @@ void MCMatchVarProcessor::Process(const InputCollections& input,VariableContaine
 
   reco::GenParticle b1;
   reco::GenParticle b2;
+  reco::GenParticle Zb1;
+  reco::GenParticle Zb2;
   reco::GenParticle decProd1;
   reco::GenParticle decProd2;
 
-//if(higgs_bs.size()>2)std::cout<<"MORE THAN TWO HIGGS PRODUCTS"<<std::endl;
-bool dfirst=true;
+  // find Higgs decay products
+  bool dfirst=true;
   for(auto p =higgs_bs.begin(); p!=higgs_bs.end(); p++){
     if(p->pdgId()==5) b1=*p;
     if(p->pdgId()==-5) b2=*p;
@@ -237,6 +267,7 @@ bool dfirst=true;
     }
   }
   
+  // fill Higgs decay products
   if(decProd1.pt()>0.){
     vars.FillVar("GenHiggs_DecProd1_Pt",decProd1.pt());
     vars.FillVar("GenHiggs_DecProd2_Pt",decProd2.pt());
@@ -247,13 +278,19 @@ bool dfirst=true;
     vars.FillVar("GenHiggs_DecProd1_PDGID",decProd1.pdgId());
     vars.FillVar("GenHiggs_DecProd2_PDGID",decProd2.pdgId());
   }
-  //std::cout<<decProd1.pdgId()<<" "<<decProd2.pdgId()<<std::endl;
+ 
+  // find Z decay products
+  for(auto p = Z_bs.begin(); p!=Z_bs.end(); p++) {
+    if(p->pdgId()==5) Zb1=*p;
+    if(p->pdgId()==-5) Zb2=*p;
+  }
   
   vars.FillVar( "N_GenTopLep", toplep.size());
   vars.FillVar( "N_GenTopHad", tophad.size());
   
   vector<math::XYZTLorentzVector> jetvecs = BoostedUtils::GetJetVecs(input.selectedJets);
   
+  // fill leptonic Top system
   for(size_t i=0;i<toplep.size();i++){
     vars.FillVars( "GenTopLep_Pt",i,toplep[i].pt());
     vars.FillVars( "GenTopLep_Eta",i,toplep[i].eta());
@@ -290,6 +327,8 @@ bool dfirst=true;
     }
   }
   
+
+  // fill hadronic top system
   for(size_t i=0;i<tophad.size();i++){
     vars.FillVars( "GenTopHad_Pt",i,tophad[i].pt());
     vars.FillVars( "GenTopHad_Eta",i,tophad[i].eta());
@@ -342,8 +381,27 @@ bool dfirst=true;
     if(minDrTopHadQ2<.25){
       vars.FillVars( "GenTopHad_Q2_Idx",i,idxq2);
     }
+
+    // get mass of dijet Whad system if quark indices were found
+    if(minDrTopHadQ1<.25 && minDrTopHadQ2<.25)
+    {
+        // get tri
+        math::XYZTLorentzVector hadw_vec = jetvecs[idxq1]+jetvecs[idxq2];
+        vars.FillVars("GenHadWMassFromMatchedJets",i,hadw_vec.M());
+    }
+
+    // get mass of trijet hadtop system if quark indices were found
+    if( minDrTopHadB<.25 && minDrTopHadQ1<.25 && minDrTopHadQ2<.25)
+    {
+        // get tri
+        math::XYZTLorentzVector hadtop_vec = jetvecs[idxbhad]+jetvecs[idxq1]+jetvecs[idxq2];
+        vars.FillVars("GenHadTopMassFromMatchedJets",i,hadtop_vec.M());
+    }
+    
   }
 
+
+  // fill higgs system
   if(higgs.pt()>0.){
     vars.FillVar( "GenHiggs_Pt",higgs.pt());
     vars.FillVar( "GenHiggs_Eta",higgs.eta());
@@ -387,7 +445,75 @@ bool dfirst=true;
     if(minDrB2<.25){
       vars.FillVar( "GenHiggs_B2_Idx",idxb2);
     }
+
+    // get mass of dijet system of B indices were found
+    if( minDrB1<.25 && minDrB2<.25 )
+    {
+        // get dijet
+        math::XYZTLorentzVector higgs_vec = jetvecs[idxb1]+jetvecs[idxb2];
+        vars.FillVar("GenHiggsMassFromMatchedJets", higgs_vec.M());
+    }
+
   }
+
+
+  // fill Z system
+  if(Z.pt()>0.){
+    vars.FillVar( "GenZ_Pt",Z.pt());
+    vars.FillVar( "GenZ_Eta",Z.eta());
+    vars.FillVar( "GenZ_Phi",Z.phi());
+    vars.FillVar( "GenZ_E",Z.energy());
+    vars.FillVar( "GenZ_Y",Z.rapidity());
+  }
+  if(Zb1.pt()>0.){
+    vars.FillVar("GenZ_B1_Pt",Zb1.pt());
+    vars.FillVar("GenZ_B2_Pt",Zb2.pt());
+    vars.FillVar("GenZ_B1_Eta",Zb1.eta());
+    vars.FillVar("GenZ_B2_Eta",Zb2.eta());
+    vars.FillVar("GenZ_B1_Phi",Zb1.phi());
+    vars.FillVar("GenZ_B2_Phi",Zb2.phi());
+    vars.FillVar("GenZ_B1_E",Zb1.energy());
+    vars.FillVar("GenZ_B2_E",Zb2.energy());
+    
+    int idxb1=-1;
+    int idxb2=-1;
+    
+    double minDrB1 = 999;
+    double minDrB2 = 999;
+    
+    for(std::vector<math::XYZTLorentzVector>::iterator itJetVec = jetvecs.begin() ; itJetVec != jetvecs.end(); ++itJetVec){
+      assert(itJetVec->pt()>0);
+      assert(Zb1.pt()>0);
+      assert(Zb2.pt()>0);
+      if(BoostedUtils::DeltaR(*itJetVec,Zb1.p4())<minDrB1){
+        idxb1 = itJetVec-jetvecs.begin();
+        minDrB1 = BoostedUtils::DeltaR(*itJetVec,Zb1.p4());
+      }
+      if(BoostedUtils::DeltaR(*itJetVec,Zb2.p4())<minDrB2){
+        idxb2 = itJetVec-jetvecs.begin();
+        minDrB2 = BoostedUtils::DeltaR(*itJetVec,Zb2.p4());
+      }
+    }
+    
+    if(minDrB1<.25){
+      vars.FillVar( "GenZ_B1_Idx",idxb1);
+    }
+    if(minDrB2<.25){
+      vars.FillVar( "GenZ_B2_Idx",idxb2);
+    }
+
+    // get mass of dijet system of B indices were found
+    if( minDrB1<.25 && minDrB2<.25 )
+    {
+        // get dijet
+        math::XYZTLorentzVector Z_vec = jetvecs[idxb1]+jetvecs[idxb2];
+        vars.FillVar("GenZMassFromMatchedJets", Z_vec.M());
+    }
+
+  }
+
+
+  // fill semileptonic gen top event stuff
   if(input.genTopEvt.IsFilled()&&input.genTopEvt.TTxIsFilled()&&input.genTopEvt.IsSemiLepton()){
     std::vector<reco::GenJet> bhad_genjet=input.genTopEvt.GetAllTopHadBGenJets();
     std::vector<reco::GenJet> blep_genjet=input.genTopEvt.GetAllTopLepBGenJets();
@@ -474,15 +600,6 @@ bool dfirst=true;
   }
 
     if(input.genTopEvt.IsFilled()&&input.genTopEvt.TTxIsFilled()&&input.genTopEvt.IsSemiLepton()) {
-        // get gen particles
-        // b quark from had top
-        //std::vector<reco::GenParticle> bhad_quark=input.genTopEvt.GetAllTopHadDecayQuarks();
-        // b quark from lep top    
-        //std::vector<reco::GenParticle> blep_quark=input.genTopEvt.GetAllTopLepDecayQuarks();
-        //b quarks from higgs
-        //std::vector<reco::GenParticle> bhiggs_quarks = input.genTopEvt.GetHiggsDecayProducts();
-        // quarks from W decay
-        //std::vector<reco::GenParticle> hadw_quarks=input.genTopEvt.GetWQuarks();
 
         double dR_bhad;
         double dR_blep;

--- a/BoostedAnalyzer/src/essentialBasicVarProcessor.cpp
+++ b/BoostedAnalyzer/src/essentialBasicVarProcessor.cpp
@@ -91,7 +91,7 @@ void essentialBasicVarProcessor::Init(const InputCollections& input,VariableCont
     vars.InitVars( "Jet_DeepJet_g","N_Jets");
 
     vars.InitVars( "TaggedJet_E","N_BTagsM" );
-    ars.InitVars( "TaggedJet_M","N_BTagsM" );
+    vars.InitVars( "TaggedJet_M","N_BTagsM" );
     vars.InitVars( "TaggedJet_Pt","N_BTagsM" );
     vars.InitVars( "TaggedJet_Phi","N_BTagsM" );
     vars.InitVars( "TaggedJet_Eta","N_BTagsM" );

--- a/BoostedAnalyzer/src/essentialBasicVarProcessor.cpp
+++ b/BoostedAnalyzer/src/essentialBasicVarProcessor.cpp
@@ -34,33 +34,33 @@ void essentialBasicVarProcessor::Init(const InputCollections& input,VariableCont
 
 
     
-    //vars.InitVars( "LooseJet_E","N_LooseJets" );
-    //vars.InitVars( "LooseJet_M","N_LooseJets" );
-    //vars.InitVars( "LooseJet_Pt","N_LooseJets" );
-    //vars.InitVars( "LooseJet_Phi","N_LooseJets" );
-    //vars.InitVars( "LooseJet_Eta","N_LooseJets" );
-    //vars.InitVars( "LooseJet_CSV","N_LooseJets" );
-    //vars.InitVars( "LooseJet_Flav","N_LooseJets" );
-    //vars.InitVars( "LooseJet_PartonFlav","N_LooseJets" );
-    //vars.InitVars( "LooseJet_Charge","N_LooseJets" );
-    //vars.InitVars( "LooseJet_PileUpID","N_LooseJets" );
-    //vars.InitVars( "LooseJet_PileUpMVA","N_LooseJets" );
+    vars.InitVars( "LooseJet_E","N_LooseJets" );
+    vars.InitVars( "LooseJet_M","N_LooseJets" );
+    vars.InitVars( "LooseJet_Pt","N_LooseJets" );
+    vars.InitVars( "LooseJet_Phi","N_LooseJets" );
+    vars.InitVars( "LooseJet_Eta","N_LooseJets" );
+    vars.InitVars( "LooseJet_CSV","N_LooseJets" );
+    vars.InitVars( "LooseJet_Flav","N_LooseJets" );
+    vars.InitVars( "LooseJet_PartonFlav","N_LooseJets" );
+    vars.InitVars( "LooseJet_Charge","N_LooseJets" );
+    vars.InitVars( "LooseJet_PileUpID","N_LooseJets" );
+    vars.InitVars( "LooseJet_PileUpMVA","N_LooseJets" );
 
-    //vars.InitVars( "LooseJet_GenJet_Pt","N_LooseJets" );
-    //vars.InitVars( "LooseJet_GenJet_Eta","N_LooseJets" );
-    //
-    //vars.InitVars( "LooseJet_DeepCSV_b","N_LooseJets");
-    //vars.InitVars( "LooseJet_DeepCSV_bb","N_LooseJets");
-    //vars.InitVars( "LooseJet_DeepCSV_c","N_LooseJets");
-    //vars.InitVars( "LooseJet_DeepCSV_udsg","N_LooseJets");
+    vars.InitVars( "LooseJet_GenJet_Pt","N_LooseJets" );
+    vars.InitVars( "LooseJet_GenJet_Eta","N_LooseJets" );
+    
+    vars.InitVars( "LooseJet_DeepCSV_b","N_LooseJets");
+    vars.InitVars( "LooseJet_DeepCSV_bb","N_LooseJets");
+    vars.InitVars( "LooseJet_DeepCSV_c","N_LooseJets");
+    vars.InitVars( "LooseJet_DeepCSV_udsg","N_LooseJets");
 
-    //vars.InitVars( "LooseJet_DeepJetCSV","N_LooseJets");
-    //vars.InitVars( "LooseJet_DeepJet_b","N_LooseJets");
-    //vars.InitVars( "LooseJet_DeepJet_bb","N_LooseJets");
-    //vars.InitVars( "LooseJet_DeepJet_lepb","N_LooseJets");
-    //vars.InitVars( "LooseJet_DeepJet_c","N_LooseJets");
-    //vars.InitVars( "LooseJet_DeepJet_uds","N_LooseJets");
-    //vars.InitVars( "LooseJet_DeepJet_g","N_LooseJets");
+    vars.InitVars( "LooseJet_DeepJetCSV","N_LooseJets");
+    vars.InitVars( "LooseJet_DeepJet_b","N_LooseJets");
+    vars.InitVars( "LooseJet_DeepJet_bb","N_LooseJets");
+    vars.InitVars( "LooseJet_DeepJet_lepb","N_LooseJets");
+    vars.InitVars( "LooseJet_DeepJet_c","N_LooseJets");
+    vars.InitVars( "LooseJet_DeepJet_uds","N_LooseJets");
+    vars.InitVars( "LooseJet_DeepJet_g","N_LooseJets");
     
     vars.InitVars( "Jet_E","N_Jets" );
     vars.InitVars( "Jet_M","N_Jets" );
@@ -77,10 +77,10 @@ void essentialBasicVarProcessor::Init(const InputCollections& input,VariableCont
     vars.InitVars( "Jet_GenJet_Pt","N_Jets" );
     vars.InitVars( "Jet_GenJet_Eta","N_Jets" );
     
-    //vars.InitVars( "Jet_DeepCSV_b","N_Jets");
-    //vars.InitVars( "Jet_DeepCSV_bb","N_Jets");
-    //vars.InitVars( "Jet_DeepCSV_c","N_Jets");
-    //vars.InitVars( "Jet_DeepCSV_udsg","N_Jets");
+    vars.InitVars( "Jet_DeepCSV_b","N_Jets");
+    vars.InitVars( "Jet_DeepCSV_bb","N_Jets");
+    vars.InitVars( "Jet_DeepCSV_c","N_Jets");
+    vars.InitVars( "Jet_DeepCSV_udsg","N_Jets");
 
     vars.InitVars( "Jet_DeepJetCSV","N_Jets");    
     vars.InitVars( "Jet_DeepJet_b","N_Jets");
@@ -90,25 +90,25 @@ void essentialBasicVarProcessor::Init(const InputCollections& input,VariableCont
     vars.InitVars( "Jet_DeepJet_uds","N_Jets");
     vars.InitVars( "Jet_DeepJet_g","N_Jets");
 
-    //vars.InitVars( "TaggedJet_E","N_BTagsM" );
-    //vars.InitVars( "TaggedJet_M","N_BTagsM" );
-    //vars.InitVars( "TaggedJet_Pt","N_BTagsM" );
-    //vars.InitVars( "TaggedJet_Phi","N_BTagsM" );
-    //vars.InitVars( "TaggedJet_Eta","N_BTagsM" );
-    //vars.InitVars( "TaggedJet_CSV","N_BTagsM" );
-    //vars.InitVars( "TaggedJet_DeepJetCSV","N_BTagsM" );
-    //vars.InitVars( "TaggedJet_DeepJet_b","N_BTagsM" );
-    //vars.InitVars( "TaggedJet_DeepJet_bb","N_BTagsM" );
-    //vars.InitVars( "TaggedJet_DeepJet_lepb","N_BTagsM" );
-    //vars.InitVars( "TaggedJet_DeepJet_c","N_BTagsM" );
-    //vars.InitVars( "TaggedJet_DeepJet_uds","N_BTagsM" );
-    //vars.InitVars( "TaggedJet_DeepJet_g","N_BTagsM" );
+    vars.InitVars( "TaggedJet_E","N_BTagsM" );
+    ars.InitVars( "TaggedJet_M","N_BTagsM" );
+    vars.InitVars( "TaggedJet_Pt","N_BTagsM" );
+    vars.InitVars( "TaggedJet_Phi","N_BTagsM" );
+    vars.InitVars( "TaggedJet_Eta","N_BTagsM" );
+    vars.InitVars( "TaggedJet_CSV","N_BTagsM" );
+    vars.InitVars( "TaggedJet_DeepJetCSV","N_BTagsM" );
+    vars.InitVars( "TaggedJet_DeepJet_b","N_BTagsM" );
+    vars.InitVars( "TaggedJet_DeepJet_bb","N_BTagsM" );
+    vars.InitVars( "TaggedJet_DeepJet_lepb","N_BTagsM" );
+    vars.InitVars( "TaggedJet_DeepJet_c","N_BTagsM" );
+    vars.InitVars( "TaggedJet_DeepJet_uds","N_BTagsM" );
+    vars.InitVars( "TaggedJet_DeepJet_g","N_BTagsM" );
 
-    //vars.InitVars( "TightLepton_E","N_TightLeptons" );    
-    //vars.InitVars( "TightLepton_M","N_TightLeptons" );    
-    //vars.InitVars( "TightLepton_Pt","N_TightLeptons" );    
-    //vars.InitVars( "TightLepton_Eta","N_TightLeptons" );    
-    //vars.InitVars( "TightLepton_Phi","N_TightLeptons" );    
+    vars.InitVars( "TightLepton_E","N_TightLeptons" );    
+    vars.InitVars( "TightLepton_M","N_TightLeptons" );    
+    vars.InitVars( "TightLepton_Pt","N_TightLeptons" );    
+    vars.InitVars( "TightLepton_Eta","N_TightLeptons" );    
+    vars.InitVars( "TightLepton_Phi","N_TightLeptons" );    
 
     vars.InitVars( "LooseLepton_E","N_LooseLeptons" );
     vars.InitVars( "LooseLepton_M","N_LooseLeptons" );
@@ -116,23 +116,23 @@ void essentialBasicVarProcessor::Init(const InputCollections& input,VariableCont
     vars.InitVars( "LooseLepton_Eta","N_LooseLeptons" );
     vars.InitVars( "LooseLepton_Phi","N_LooseLeptons" );
     
-    //vars.InitVars( "LooseMuon_E","N_LooseMuons" );
-    //vars.InitVars( "LooseMuon_M","N_LooseMuons" );
-    //vars.InitVars( "LooseMuon_Pt","N_LooseMuons" );
-    //vars.InitVars( "LooseMuon_Eta","N_LooseMuons" );
-    //vars.InitVars( "LooseMuon_Phi","N_LooseMuons" );
-    //vars.InitVars( "LooseMuon_RelIso","N_LooseMuons" );
-    //vars.InitVars( "LooseMuon_Charge","N_LooseMuons" );
-    //vars.InitVars( "LooseMuon_Pt_BeForeRC","N_LooseMuons" );
-    //vars.InitVars( "LooseMuon_roccorSF", "N_LooseMuons");
-    //vars.InitVars( "LooseMuon_roccorSFUp", "N_LooseMuons");
-    //vars.InitVars( "LooseMuon_roccorSFDown", "N_LooseMuons");
-    //vars.InitVars( "LooseMuon_IdentificationSF","N_LooseMuons");
-    //vars.InitVars( "LooseMuon_IdentificationSFUp","N_LooseMuons");
-    //vars.InitVars( "LooseMuon_IdentificationSFDown","N_LooseMuons");
-    //vars.InitVars( "LooseMuon_IsolationSF","N_LooseMuons");
-    //vars.InitVars( "LooseMuon_IsolationSFUp","N_LooseMuons");
-    //vars.InitVars( "LooseMuon_IsolationSFDown","N_LooseMuons");
+    vars.InitVars( "LooseMuon_E","N_LooseMuons" );
+    vars.InitVars( "LooseMuon_M","N_LooseMuons" );
+    vars.InitVars( "LooseMuon_Pt","N_LooseMuons" );
+    vars.InitVars( "LooseMuon_Eta","N_LooseMuons" );
+    vars.InitVars( "LooseMuon_Phi","N_LooseMuons" );
+    vars.InitVars( "LooseMuon_RelIso","N_LooseMuons" );
+    vars.InitVars( "LooseMuon_Charge","N_LooseMuons" );
+    vars.InitVars( "LooseMuon_Pt_BeForeRC","N_LooseMuons" );
+    vars.InitVars( "LooseMuon_roccorSF", "N_LooseMuons");
+    vars.InitVars( "LooseMuon_roccorSFUp", "N_LooseMuons");
+    vars.InitVars( "LooseMuon_roccorSFDown", "N_LooseMuons");
+    vars.InitVars( "LooseMuon_IdentificationSF","N_LooseMuons");
+    vars.InitVars( "LooseMuon_IdentificationSFUp","N_LooseMuons");
+    vars.InitVars( "LooseMuon_IdentificationSFDown","N_LooseMuons");
+    vars.InitVars( "LooseMuon_IsolationSF","N_LooseMuons");
+    vars.InitVars( "LooseMuon_IsolationSFUp","N_LooseMuons");
+    vars.InitVars( "LooseMuon_IsolationSFDown","N_LooseMuons");
 
     vars.InitVars( "Muon_E","N_TightMuons" );
     vars.InitVars( "Muon_M","N_TightMuons" );
@@ -154,27 +154,27 @@ void essentialBasicVarProcessor::Init(const InputCollections& input,VariableCont
 
 
     
-    //vars.InitVars( "LooseElectron_E","N_LooseElectrons" );
-    //vars.InitVars( "LooseElectron_M","N_LooseElectrons" );
-    //vars.InitVars( "LooseElectron_Pt","N_LooseElectrons" );
-    //vars.InitVars( "LooseElectron_Eta","N_LooseElectrons" );
-    //vars.InitVars( "LooseElectron_Phi","N_LooseElectrons" );
-    //vars.InitVars( "LooseElectron_RelIso","N_LooseElectrons" );
-    //vars.InitVars( "LooseElectron_Charge","N_LooseElectrons" );
-    //vars.InitVars( "LooseElectron_Pt_BeforeRun2Calibration","N_LooseElectrons" );
-    //vars.InitVars( "LooseElectron_Eta_Supercluster","N_LooseElectrons" );
-    //// electron energy scale combined up/down
-    //vars.InitVars( "LooseElectron_CorrFactor_ScaleUp","N_LooseElectrons");
-    //vars.InitVars( "LooseElectron_CorrFactor_ScaleDown","N_LooseElectrons");
-    //// electron energy smearing combined up/down
-    //vars.InitVars( "LooseElectron_CorrFactor_SigmaUp","N_LooseElectrons");
-    //vars.InitVars( "LooseElectron_CorrFactor_SigmaDown","N_LooseElectrons");
-    //vars.InitVars( "LooseElectron_IdentificationSF","N_LooseElectrons");
-    //vars.InitVars( "LooseElectron_IdentificationSFUp","N_LooseElectrons");
-    //vars.InitVars( "LooseElectron_IdentificationSFDown","N_LooseElectrons");
-    //vars.InitVars( "LooseElectron_ReconstructionSF","N_LooseElectrons");
-    //vars.InitVars( "LooseElectron_ReconstructionSFUp","N_LooseElectrons");
-    //vars.InitVars( "LooseElectron_ReconstructionSFDown","N_LooseElectrons");
+    vars.InitVars( "LooseElectron_E","N_LooseElectrons" );
+    vars.InitVars( "LooseElectron_M","N_LooseElectrons" );
+    vars.InitVars( "LooseElectron_Pt","N_LooseElectrons" );
+    vars.InitVars( "LooseElectron_Eta","N_LooseElectrons" );
+    vars.InitVars( "LooseElectron_Phi","N_LooseElectrons" );
+    vars.InitVars( "LooseElectron_RelIso","N_LooseElectrons" );
+    vars.InitVars( "LooseElectron_Charge","N_LooseElectrons" );
+    vars.InitVars( "LooseElectron_Pt_BeforeRun2Calibration","N_LooseElectrons" );
+    vars.InitVars( "LooseElectron_Eta_Supercluster","N_LooseElectrons" );
+    // electron energy scale combined up/down
+    vars.InitVars( "LooseElectron_CorrFactor_ScaleUp","N_LooseElectrons");
+    vars.InitVars( "LooseElectron_CorrFactor_ScaleDown","N_LooseElectrons");
+    // electron energy smearing combined up/down
+    vars.InitVars( "LooseElectron_CorrFactor_SigmaUp","N_LooseElectrons");
+    vars.InitVars( "LooseElectron_CorrFactor_SigmaDown","N_LooseElectrons");
+    vars.InitVars( "LooseElectron_IdentificationSF","N_LooseElectrons");
+    vars.InitVars( "LooseElectron_IdentificationSFUp","N_LooseElectrons");
+    vars.InitVars( "LooseElectron_IdentificationSFDown","N_LooseElectrons");
+    vars.InitVars( "LooseElectron_ReconstructionSF","N_LooseElectrons");
+    vars.InitVars( "LooseElectron_ReconstructionSFUp","N_LooseElectrons");
+    vars.InitVars( "LooseElectron_ReconstructionSFDown","N_LooseElectrons");
     
     vars.InitVars( "Electron_E","N_TightElectrons" );
     vars.InitVars( "Electron_M","N_TightElectrons" );
@@ -286,10 +286,10 @@ void essentialBasicVarProcessor::Process(const InputCollections& input,VariableC
             vars.FillVars( "Jet_GenJet_Eta",iJet,-9.0);
         }
 
-        //vars.FillVars( "Jet_DeepCSV_b",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probb"));
-        //vars.FillVars( "Jet_DeepCSV_bb",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probbb"));
-        //vars.FillVars( "Jet_DeepCSV_c",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probc"));
-        //vars.FillVars( "Jet_DeepCSV_udsg",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probudsg"));
+        vars.FillVars( "Jet_DeepCSV_b",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probb"));
+        vars.FillVars( "Jet_DeepCSV_bb",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probbb"));
+        vars.FillVars( "Jet_DeepCSV_c",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probc"));
+        vars.FillVars( "Jet_DeepCSV_udsg",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probudsg"));
         
         vars.FillVars( "Jet_DeepJetCSV",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"DeepJet"));
         vars.FillVars( "Jet_DeepJet_b",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probb"));
@@ -300,82 +300,82 @@ void essentialBasicVarProcessor::Process(const InputCollections& input,VariableC
         vars.FillVars( "Jet_DeepJet_g",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probg"));
     }
     
-    //for(std::vector<pat::Jet>::const_iterator itJet = input.selectedJetsLoose.begin() ; itJet != input.selectedJetsLoose.end(); ++itJet)
-    //{
-    //    int iJet = itJet - input.selectedJetsLoose.begin();
-    //    vars.FillVars( "LooseJet_E",iJet,itJet->energy() );
-    //    vars.FillVars( "LooseJet_M",iJet,itJet->mass() );
-    //    vars.FillVars( "LooseJet_Pt",iJet,itJet->pt() );
-    //    vars.FillVars( "LooseJet_Eta",iJet,itJet->eta() );
-    //    vars.FillVars( "LooseJet_Phi",iJet,itJet->phi() );
-    //    vars.FillVars( "LooseJet_CSV",iJet,CSVHelper::GetJetCSV(*itJet,btagger) );
-    //    //vars.FillVars( "LooseJet_CSV_DNN",iJet,CSVHelper::GetJetCSV_DNN(*itJet,btagger) );
-    //    vars.FillVars( "LooseJet_Flav",iJet,itJet->hadronFlavour() );
-    //    vars.FillVars( "LooseJet_PartonFlav",iJet,itJet->partonFlavour() );
-    //    vars.FillVars( "LooseJet_Charge",iJet,itJet->jetCharge() );
-    //    if(itJet->hasUserInt("pileupJetIdUpdated:fullId")) 
-    //        vars.FillVars( "LooseJet_PileUpID",iJet,itJet->userInt("pileupJetIdUpdated:fullId"));
-    //    if(itJet->hasUserFloat("pileupJetIdUpdated:fullDiscriminant")) 
-    //            vars.FillVars( "LooseJet_PileUpMVA",iJet,itJet->userFloat("pileupJetIdUpdated:fullDiscriminant"));
+    for(std::vector<pat::Jet>::const_iterator itJet = input.selectedJetsLoose.begin() ; itJet != input.selectedJetsLoose.end(); ++itJet)
+    {
+        int iJet = itJet - input.selectedJetsLoose.begin();
+        vars.FillVars( "LooseJet_E",iJet,itJet->energy() );
+        vars.FillVars( "LooseJet_M",iJet,itJet->mass() );
+        vars.FillVars( "LooseJet_Pt",iJet,itJet->pt() );
+        vars.FillVars( "LooseJet_Eta",iJet,itJet->eta() );
+        vars.FillVars( "LooseJet_Phi",iJet,itJet->phi() );
+        vars.FillVars( "LooseJet_CSV",iJet,CSVHelper::GetJetCSV(*itJet,btagger) );
+        //vars.FillVars( "LooseJet_CSV_DNN",iJet,CSVHelper::GetJetCSV_DNN(*itJet,btagger) );
+        vars.FillVars( "LooseJet_Flav",iJet,itJet->hadronFlavour() );
+        vars.FillVars( "LooseJet_PartonFlav",iJet,itJet->partonFlavour() );
+        vars.FillVars( "LooseJet_Charge",iJet,itJet->jetCharge() );
+        if(itJet->hasUserInt("pileupJetIdUpdated:fullId")) 
+            vars.FillVars( "LooseJet_PileUpID",iJet,itJet->userInt("pileupJetIdUpdated:fullId"));
+        if(itJet->hasUserFloat("pileupJetIdUpdated:fullDiscriminant")) 
+                vars.FillVars( "LooseJet_PileUpMVA",iJet,itJet->userFloat("pileupJetIdUpdated:fullDiscriminant"));
 
-    //    if(itJet->genJet()!=NULL)
-    //    {
-    //        vars.FillVars( "LooseJet_GenJet_Pt",iJet,itJet->genJet()->pt());
-    //        vars.FillVars( "LooseJet_GenJet_Eta",iJet,itJet->genJet()->eta());
-    //    }
-    //    else 
-    //    {
-    //        vars.FillVars( "LooseJet_GenJet_Pt",iJet,-9.0);
-    //        vars.FillVars( "LooseJet_GenJet_Eta",iJet,-9.0);
-    //    }
+        if(itJet->genJet()!=NULL)
+        {
+            vars.FillVars( "LooseJet_GenJet_Pt",iJet,itJet->genJet()->pt());
+            vars.FillVars( "LooseJet_GenJet_Eta",iJet,itJet->genJet()->eta());
+        }
+        else 
+        {
+            vars.FillVars( "LooseJet_GenJet_Pt",iJet,-9.0);
+            vars.FillVars( "LooseJet_GenJet_Eta",iJet,-9.0);
+        }
 
-    //    vars.FillVars( "LooseJet_DeepCSV_b",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probb"));
-    //    vars.FillVars( "LooseJet_DeepCSV_bb",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probbb"));
-    //    vars.FillVars( "LooseJet_DeepCSV_c",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probc"));
-    //    vars.FillVars( "LooseJet_DeepCSV_udsg",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probudsg"));
-    //    
-    //    vars.FillVars( "LooseJet_DeepJetCSV",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"DeepJet"));
-    //    vars.FillVars( "LooseJet_DeepJet_b",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probb"));
-    //    vars.FillVars( "LooseJet_DeepJet_bb",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probbb"));
-    //    vars.FillVars( "LooseJet_DeepJet_lepb",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:problepb"));
-    //    vars.FillVars( "LooseJet_DeepJet_c",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probc"));
-    //    vars.FillVars( "LooseJet_DeepJet_uds",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probuds"));
-    //    vars.FillVars( "LooseJet_DeepJet_g",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probg"));
-    //}
+        vars.FillVars( "LooseJet_DeepCSV_b",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probb"));
+        vars.FillVars( "LooseJet_DeepCSV_bb",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probbb"));
+        vars.FillVars( "LooseJet_DeepCSV_c",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probc"));
+        vars.FillVars( "LooseJet_DeepCSV_udsg",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probudsg"));
+        
+        vars.FillVars( "LooseJet_DeepJetCSV",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"DeepJet"));
+        vars.FillVars( "LooseJet_DeepJet_b",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probb"));
+        vars.FillVars( "LooseJet_DeepJet_bb",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probbb"));
+        vars.FillVars( "LooseJet_DeepJet_lepb",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:problepb"));
+        vars.FillVars( "LooseJet_DeepJet_c",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probc"));
+        vars.FillVars( "LooseJet_DeepJet_uds",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probuds"));
+        vars.FillVars( "LooseJet_DeepJet_g",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probg"));
+    }
 
     
 
     
     // Tagged Jets
-    //for(std::vector<pat::Jet>::iterator itTaggedJet = selectedTaggedJets.begin() ; itTaggedJet != selectedTaggedJets.end(); ++itTaggedJet)
-    //{
-    //    int iTaggedJet = itTaggedJet - selectedTaggedJets.begin();
-    //    vars.FillVars( "TaggedJet_E",iTaggedJet,            itTaggedJet->energy() );
-    //    vars.FillVars( "TaggedJet_M",iTaggedJet,            itTaggedJet->mass() );
-    //    vars.FillVars( "TaggedJet_Pt",iTaggedJet,           itTaggedJet->pt() );
-    //    vars.FillVars( "TaggedJet_Eta",iTaggedJet,          itTaggedJet->eta() );
-    //    vars.FillVars( "TaggedJet_Phi",iTaggedJet,          itTaggedJet->phi() );
-    //    vars.FillVars( "TaggedJet_CSV",iTaggedJet,          CSVHelper::GetJetCSV(*itTaggedJet,btagger));
-    //    vars.FillVars( "TaggedJet_DeepJetCSV",iTaggedJet,   CSVHelper::GetJetCSV_DNN(*itTaggedJet,"DeepJet"));
-    //    vars.FillVars( "TaggedJet_DeepJet_b",iTaggedJet,    CSVHelper::GetJetCSV_DNN(*itTaggedJet,"pfDeepFlavourJetTags:probb"));
-    //    vars.FillVars( "TaggedJet_DeepJet_bb",iTaggedJet,   CSVHelper::GetJetCSV_DNN(*itTaggedJet,"pfDeepFlavourJetTags:probbb"));
-    //    vars.FillVars( "TaggedJet_DeepJet_lepb",iTaggedJet, CSVHelper::GetJetCSV_DNN(*itTaggedJet,"pfDeepFlavourJetTags:problepb"));
-    //    vars.FillVars( "TaggedJet_DeepJet_c",iTaggedJet,    CSVHelper::GetJetCSV_DNN(*itTaggedJet,"pfDeepFlavourJetTags:probc"));
-    //    vars.FillVars( "TaggedJet_DeepJet_uds",iTaggedJet,  CSVHelper::GetJetCSV_DNN(*itTaggedJet,"pfDeepFlavourJetTags:probuds"));
-    //    vars.FillVars( "TaggedJet_DeepJet_g",iTaggedJet,    CSVHelper::GetJetCSV_DNN(*itTaggedJet,"pfDeepFlavourJetTags:probg"));
-    //}
+    for(std::vector<pat::Jet>::iterator itTaggedJet = selectedTaggedJets.begin() ; itTaggedJet != selectedTaggedJets.end(); ++itTaggedJet)
+    {
+        int iTaggedJet = itTaggedJet - selectedTaggedJets.begin();
+        vars.FillVars( "TaggedJet_E",iTaggedJet,            itTaggedJet->energy() );
+        vars.FillVars( "TaggedJet_M",iTaggedJet,            itTaggedJet->mass() );
+        vars.FillVars( "TaggedJet_Pt",iTaggedJet,           itTaggedJet->pt() );
+        vars.FillVars( "TaggedJet_Eta",iTaggedJet,          itTaggedJet->eta() );
+        vars.FillVars( "TaggedJet_Phi",iTaggedJet,          itTaggedJet->phi() );
+        vars.FillVars( "TaggedJet_CSV",iTaggedJet,          CSVHelper::GetJetCSV(*itTaggedJet,btagger));
+        vars.FillVars( "TaggedJet_DeepJetCSV",iTaggedJet,   CSVHelper::GetJetCSV_DNN(*itTaggedJet,"DeepJet"));
+        vars.FillVars( "TaggedJet_DeepJet_b",iTaggedJet,    CSVHelper::GetJetCSV_DNN(*itTaggedJet,"pfDeepFlavourJetTags:probb"));
+        vars.FillVars( "TaggedJet_DeepJet_bb",iTaggedJet,   CSVHelper::GetJetCSV_DNN(*itTaggedJet,"pfDeepFlavourJetTags:probbb"));
+        vars.FillVars( "TaggedJet_DeepJet_lepb",iTaggedJet, CSVHelper::GetJetCSV_DNN(*itTaggedJet,"pfDeepFlavourJetTags:problepb"));
+        vars.FillVars( "TaggedJet_DeepJet_c",iTaggedJet,    CSVHelper::GetJetCSV_DNN(*itTaggedJet,"pfDeepFlavourJetTags:probc"));
+        vars.FillVars( "TaggedJet_DeepJet_uds",iTaggedJet,  CSVHelper::GetJetCSV_DNN(*itTaggedJet,"pfDeepFlavourJetTags:probuds"));
+        vars.FillVars( "TaggedJet_DeepJet_g",iTaggedJet,    CSVHelper::GetJetCSV_DNN(*itTaggedJet,"pfDeepFlavourJetTags:probg"));
+    }
 
     // Fill Lepton Variables
     std::vector<math::XYZTLorentzVector> tightLeptonVecs = BoostedUtils::GetLepVecs(input.selectedElectrons,input.selectedMuons);
-    //for(auto itLep = tightLeptonVecs.begin(); itLep != tightLeptonVecs.end(); ++itLep)
-    //{
-    //    int iLep = itLep - tightLeptonVecs.begin();
-    //    vars.FillVars( "TightLepton_E",iLep,itLep->E() );
-    //    vars.FillVars( "TightLepton_M",iLep,itLep->M() );
-    //    vars.FillVars( "TightLepton_Pt",iLep,itLep->Pt() );
-    //    vars.FillVars( "TightLepton_Eta",iLep,itLep->Eta());
-    //    vars.FillVars( "TightLepton_Phi",iLep,itLep->Phi() );
-    //}
+    for(auto itLep = tightLeptonVecs.begin(); itLep != tightLeptonVecs.end(); ++itLep)
+    {
+        int iLep = itLep - tightLeptonVecs.begin();
+        vars.FillVars( "TightLepton_E",iLep,itLep->E() );
+        vars.FillVars( "TightLepton_M",iLep,itLep->M() );
+        vars.FillVars( "TightLepton_Pt",iLep,itLep->Pt() );
+        vars.FillVars( "TightLepton_Eta",iLep,itLep->Eta());
+        vars.FillVars( "TightLepton_Phi",iLep,itLep->Phi() );
+    }
     std::vector<math::XYZTLorentzVector> looseLeptonVecs = BoostedUtils::GetLepVecs(input.selectedElectronsLoose,input.selectedMuonsLoose);
     for(std::vector<math::XYZTLorentzVector>::iterator itLep = looseLeptonVecs.begin() ; itLep != looseLeptonVecs.end(); ++itLep)
     {
@@ -387,41 +387,41 @@ void essentialBasicVarProcessor::Process(const InputCollections& input,VariableC
         vars.FillVars( "LooseLepton_Phi",iLep,itLep->Phi() );
     }
      
-    //for(std::vector<pat::Electron>::const_iterator itEle = input.selectedElectronsLoose.begin(); itEle != input.selectedElectronsLoose.end(); ++itEle)
-    //{
-    //    int iEle = itEle - input.selectedElectronsLoose.begin();
-    //    vars.FillVars( "LooseElectron_E",iEle,itEle->energy() );
-    //    vars.FillVars( "LooseElectron_M",iEle,itEle->mass() );
-    //    vars.FillVars( "LooseElectron_Pt",iEle,itEle->pt() );
-    //    vars.FillVars( "LooseElectron_Eta",iEle,itEle->eta() );
-    //    vars.FillVars( "LooseElectron_Phi",iEle,itEle->phi() ); 
-    //    if(itEle->hasUserFloat("relIso"))
-    //        vars.FillVars( "LooseElectron_RelIso",iEle,itEle->userFloat("relIso") );
+    for(std::vector<pat::Electron>::const_iterator itEle = input.selectedElectronsLoose.begin(); itEle != input.selectedElectronsLoose.end(); ++itEle)
+    {
+        int iEle = itEle - input.selectedElectronsLoose.begin();
+        vars.FillVars( "LooseElectron_E",iEle,itEle->energy() );
+        vars.FillVars( "LooseElectron_M",iEle,itEle->mass() );
+        vars.FillVars( "LooseElectron_Pt",iEle,itEle->pt() );
+        vars.FillVars( "LooseElectron_Eta",iEle,itEle->eta() );
+        vars.FillVars( "LooseElectron_Phi",iEle,itEle->phi() ); 
+        if(itEle->hasUserFloat("relIso"))
+            vars.FillVars( "LooseElectron_RelIso",iEle,itEle->userFloat("relIso") );
 
-    //    vars.FillVars( "LooseElectron_Charge",iEle,itEle->charge() ); 
-    //    if(itEle->hasUserFloat("ptBeforeRun2Calibration"))
-    //        vars.FillVars("LooseElectron_Pt_BeforeRun2Calibration",iEle,itEle->userFloat("ptBeforeRun2Calibration"));
+        vars.FillVars( "LooseElectron_Charge",iEle,itEle->charge() ); 
+        if(itEle->hasUserFloat("ptBeforeRun2Calibration"))
+            vars.FillVars("LooseElectron_Pt_BeforeRun2Calibration",iEle,itEle->userFloat("ptBeforeRun2Calibration"));
 
-    //    vars.FillVars("LooseElectron_Eta_Supercluster",iEle,itEle->superCluster()->eta());
-    //    if(itEle->hasUserFloat("CorrFactor_ScaleUp"))
-    //    {
-    //        // electron energy scale combined up/down
-    //        vars.FillVars( "LooseElectron_CorrFactor_ScaleUp",iEle,itEle->userFloat("CorrFactor_ScaleUp"));
-    //        vars.FillVars( "LooseElectron_CorrFactor_ScaleDown",iEle,itEle->userFloat("CorrFactor_ScaleDown"));
-    //        // electron energy smearing combined up/down
-    //        vars.FillVars( "LooseElectron_CorrFactor_SigmaUp",iEle,itEle->userFloat("CorrFactor_SigmaUp"));
-    //        vars.FillVars( "LooseElectron_CorrFactor_SigmaDown",iEle,itEle->userFloat("CorrFactor_SigmaDown"));
-    //    }
-    //    if(itEle->hasUserFloat("IdentificationSF")) 
-    //    {
-    //        vars.FillVars( "LooseElectron_IdentificationSF",iEle,itEle->userFloat("IdentificationSF"));
-    //        vars.FillVars( "LooseElectron_IdentificationSFUp",iEle,itEle->userFloat("IdentificationSFUp"));
-    //        vars.FillVars( "LooseElectron_IdentificationSFDown",iEle,itEle->userFloat("IdentificationSFDown"));
-    //        vars.FillVars( "LooseElectron_ReconstructionSF",iEle,itEle->userFloat("ReconstructionSF"));
-    //        vars.FillVars( "LooseElectron_ReconstructionSFUp",iEle,itEle->userFloat("ReconstructionSFUp"));
-    //        vars.FillVars( "LooseElectron_ReconstructionSFDown",iEle,itEle->userFloat("ReconstructionSFDown"));
-    //    }
-    //}
+        vars.FillVars("LooseElectron_Eta_Supercluster",iEle,itEle->superCluster()->eta());
+        if(itEle->hasUserFloat("CorrFactor_ScaleUp"))
+        {
+            // electron energy scale combined up/down
+            vars.FillVars( "LooseElectron_CorrFactor_ScaleUp",iEle,itEle->userFloat("CorrFactor_ScaleUp"));
+            vars.FillVars( "LooseElectron_CorrFactor_ScaleDown",iEle,itEle->userFloat("CorrFactor_ScaleDown"));
+            // electron energy smearing combined up/down
+            vars.FillVars( "LooseElectron_CorrFactor_SigmaUp",iEle,itEle->userFloat("CorrFactor_SigmaUp"));
+            vars.FillVars( "LooseElectron_CorrFactor_SigmaDown",iEle,itEle->userFloat("CorrFactor_SigmaDown"));
+        }
+        if(itEle->hasUserFloat("IdentificationSF")) 
+        {
+            vars.FillVars( "LooseElectron_IdentificationSF",iEle,itEle->userFloat("IdentificationSF"));
+            vars.FillVars( "LooseElectron_IdentificationSFUp",iEle,itEle->userFloat("IdentificationSFUp"));
+            vars.FillVars( "LooseElectron_IdentificationSFDown",iEle,itEle->userFloat("IdentificationSFDown"));
+            vars.FillVars( "LooseElectron_ReconstructionSF",iEle,itEle->userFloat("ReconstructionSF"));
+            vars.FillVars( "LooseElectron_ReconstructionSFUp",iEle,itEle->userFloat("ReconstructionSFUp"));
+            vars.FillVars( "LooseElectron_ReconstructionSFDown",iEle,itEle->userFloat("ReconstructionSFDown"));
+        }
+    }
     for(std::vector<pat::Electron>::const_iterator itEle = input.selectedElectrons.begin(); itEle != input.selectedElectrons.end(); ++itEle)
     {
         int iEle = itEle - input.selectedElectrons.begin();
@@ -458,43 +458,43 @@ void essentialBasicVarProcessor::Process(const InputCollections& input,VariableC
         }
     }
     
-    //for(std::vector<pat::Muon>::const_iterator itMu = input.selectedMuonsLoose.begin(); itMu != input.selectedMuonsLoose.end(); ++itMu)
-    //{
-    //    int iMu = itMu - input.selectedMuonsLoose.begin();
-    //    vars.FillVars( "LooseMuon_E",iMu,itMu->energy() );
-    //    vars.FillVars( "LooseMuon_M",iMu,itMu->mass() );
-    //    vars.FillVars( "LooseMuon_Pt",iMu,itMu->pt() );
-    //    vars.FillVars( "LooseMuon_Eta",iMu,itMu->eta() );
-    //    vars.FillVars( "LooseMuon_Phi",iMu,itMu->phi() );
-    //    if(itMu->hasUserFloat("relIso"))
-    //        vars.FillVars( "LooseMuon_RelIso",iMu,itMu->userFloat("relIso") );
+    for(std::vector<pat::Muon>::const_iterator itMu = input.selectedMuonsLoose.begin(); itMu != input.selectedMuonsLoose.end(); ++itMu)
+    {
+        int iMu = itMu - input.selectedMuonsLoose.begin();
+        vars.FillVars( "LooseMuon_E",iMu,itMu->energy() );
+        vars.FillVars( "LooseMuon_M",iMu,itMu->mass() );
+        vars.FillVars( "LooseMuon_Pt",iMu,itMu->pt() );
+        vars.FillVars( "LooseMuon_Eta",iMu,itMu->eta() );
+        vars.FillVars( "LooseMuon_Phi",iMu,itMu->phi() );
+        if(itMu->hasUserFloat("relIso"))
+            vars.FillVars( "LooseMuon_RelIso",iMu,itMu->userFloat("relIso") );
 
-    //    vars.FillVars( "LooseMuon_Charge",iMu,itMu->charge() );
-    //    if(itMu->hasUserFloat("PtbeforeRC"))
-    //        vars.FillVars( "LooseMuon_Pt_BeForeRC",iMu,itMu->userFloat("PtbeforeRC") );
+        vars.FillVars( "LooseMuon_Charge",iMu,itMu->charge() );
+        if(itMu->hasUserFloat("PtbeforeRC"))
+            vars.FillVars( "LooseMuon_Pt_BeForeRC",iMu,itMu->userFloat("PtbeforeRC") );
 
-    //    if(itMu->hasUserFloat("roccorSF"))
-    //        vars.FillVars( "LooseMuon_roccorSF",iMu,itMu->userFloat("roccorSF") );
+        if(itMu->hasUserFloat("roccorSF"))
+            vars.FillVars( "LooseMuon_roccorSF",iMu,itMu->userFloat("roccorSF") );
 
-    //    if(itMu->hasUserFloat("roccorSFUp"))
-    //        vars.FillVars( "LooseMuon_roccorSFUp",iMu,itMu->userFloat("roccorSFUp") );
+        if(itMu->hasUserFloat("roccorSFUp"))
+            vars.FillVars( "LooseMuon_roccorSFUp",iMu,itMu->userFloat("roccorSFUp") );
 
-    //    if(itMu->hasUserFloat("roccorSFDown"))
-    //        vars.FillVars( "LooseMuon_roccorSFDown",iMu,itMu->userFloat("roccorSFDown") );
+        if(itMu->hasUserFloat("roccorSFDown"))
+            vars.FillVars( "LooseMuon_roccorSFDown",iMu,itMu->userFloat("roccorSFDown") );
 
-    //    if(itMu->hasUserFloat("IdentificationSF"))
-    //    {
-    //        vars.FillVars( "LooseMuon_IdentificationSF",iMu,itMu->userFloat("IdentificationSF"));
-    //        vars.FillVars( "LooseMuon_IdentificationSFUp",iMu,itMu->userFloat("IdentificationSFUp"));
-    //        vars.FillVars( "LooseMuon_IdentificationSFDown",iMu,itMu->userFloat("IdentificationSFDown"));
-    //    }
-    //    if(itMu->hasUserFloat("IsolationSF"))
-    //    {
-    //        vars.FillVars( "LooseMuon_IsolationSF",iMu,itMu->userFloat("IsolationSF"));
-    //        vars.FillVars( "LooseMuon_IsolationSFUp",iMu,itMu->userFloat("IsolationSFUp"));
-    //        vars.FillVars( "LooseMuon_IsolationSFDown",iMu,itMu->userFloat("IsolationSFDown"));
-    //    }
-    //}
+        if(itMu->hasUserFloat("IdentificationSF"))
+        {
+            vars.FillVars( "LooseMuon_IdentificationSF",iMu,itMu->userFloat("IdentificationSF"));
+            vars.FillVars( "LooseMuon_IdentificationSFUp",iMu,itMu->userFloat("IdentificationSFUp"));
+            vars.FillVars( "LooseMuon_IdentificationSFDown",iMu,itMu->userFloat("IdentificationSFDown"));
+        }
+        if(itMu->hasUserFloat("IsolationSF"))
+        {
+            vars.FillVars( "LooseMuon_IsolationSF",iMu,itMu->userFloat("IsolationSF"));
+            vars.FillVars( "LooseMuon_IsolationSFUp",iMu,itMu->userFloat("IsolationSFUp"));
+            vars.FillVars( "LooseMuon_IsolationSFDown",iMu,itMu->userFloat("IsolationSFDown"));
+        }
+    }
     for(std::vector<pat::Muon>::const_iterator itMu = input.selectedMuons.begin(); itMu != input.selectedMuons.end(); ++itMu)
     {
         int iMu = itMu - input.selectedMuons.begin();

--- a/BoostedAnalyzer/src/essentialBasicVarProcessor.cpp
+++ b/BoostedAnalyzer/src/essentialBasicVarProcessor.cpp
@@ -34,33 +34,33 @@ void essentialBasicVarProcessor::Init(const InputCollections& input,VariableCont
 
 
     
-    vars.InitVars( "LooseJet_E","N_LooseJets" );
-    vars.InitVars( "LooseJet_M","N_LooseJets" );
-    vars.InitVars( "LooseJet_Pt","N_LooseJets" );
-    vars.InitVars( "LooseJet_Phi","N_LooseJets" );
-    vars.InitVars( "LooseJet_Eta","N_LooseJets" );
-    vars.InitVars( "LooseJet_CSV","N_LooseJets" );
-    vars.InitVars( "LooseJet_Flav","N_LooseJets" );
-    vars.InitVars( "LooseJet_PartonFlav","N_LooseJets" );
-    vars.InitVars( "LooseJet_Charge","N_LooseJets" );
-    vars.InitVars( "LooseJet_PileUpID","N_LooseJets" );
-    vars.InitVars( "LooseJet_PileUpMVA","N_LooseJets" );
+    //vars.InitVars( "LooseJet_E","N_LooseJets" );
+    //vars.InitVars( "LooseJet_M","N_LooseJets" );
+    //vars.InitVars( "LooseJet_Pt","N_LooseJets" );
+    //vars.InitVars( "LooseJet_Phi","N_LooseJets" );
+    //vars.InitVars( "LooseJet_Eta","N_LooseJets" );
+    //vars.InitVars( "LooseJet_CSV","N_LooseJets" );
+    //vars.InitVars( "LooseJet_Flav","N_LooseJets" );
+    //vars.InitVars( "LooseJet_PartonFlav","N_LooseJets" );
+    //vars.InitVars( "LooseJet_Charge","N_LooseJets" );
+    //vars.InitVars( "LooseJet_PileUpID","N_LooseJets" );
+    //vars.InitVars( "LooseJet_PileUpMVA","N_LooseJets" );
 
-    vars.InitVars( "LooseJet_GenJet_Pt","N_LooseJets" );
-    vars.InitVars( "LooseJet_GenJet_Eta","N_LooseJets" );
-    
-    vars.InitVars( "LooseJet_DeepCSV_b","N_LooseJets");
-    vars.InitVars( "LooseJet_DeepCSV_bb","N_LooseJets");
-    vars.InitVars( "LooseJet_DeepCSV_c","N_LooseJets");
-    vars.InitVars( "LooseJet_DeepCSV_udsg","N_LooseJets");
+    //vars.InitVars( "LooseJet_GenJet_Pt","N_LooseJets" );
+    //vars.InitVars( "LooseJet_GenJet_Eta","N_LooseJets" );
+    //
+    //vars.InitVars( "LooseJet_DeepCSV_b","N_LooseJets");
+    //vars.InitVars( "LooseJet_DeepCSV_bb","N_LooseJets");
+    //vars.InitVars( "LooseJet_DeepCSV_c","N_LooseJets");
+    //vars.InitVars( "LooseJet_DeepCSV_udsg","N_LooseJets");
 
-    vars.InitVars( "LooseJet_DeepJetCSV","N_LooseJets");    
-    vars.InitVars( "LooseJet_DeepJet_b","N_LooseJets");
-    vars.InitVars( "LooseJet_DeepJet_bb","N_LooseJets");
-    vars.InitVars( "LooseJet_DeepJet_lepb","N_LooseJets");
-    vars.InitVars( "LooseJet_DeepJet_c","N_LooseJets");
-    vars.InitVars( "LooseJet_DeepJet_uds","N_LooseJets");
-    vars.InitVars( "LooseJet_DeepJet_g","N_LooseJets");
+    //vars.InitVars( "LooseJet_DeepJetCSV","N_LooseJets");
+    //vars.InitVars( "LooseJet_DeepJet_b","N_LooseJets");
+    //vars.InitVars( "LooseJet_DeepJet_bb","N_LooseJets");
+    //vars.InitVars( "LooseJet_DeepJet_lepb","N_LooseJets");
+    //vars.InitVars( "LooseJet_DeepJet_c","N_LooseJets");
+    //vars.InitVars( "LooseJet_DeepJet_uds","N_LooseJets");
+    //vars.InitVars( "LooseJet_DeepJet_g","N_LooseJets");
     
     vars.InitVars( "Jet_E","N_Jets" );
     vars.InitVars( "Jet_M","N_Jets" );
@@ -77,10 +77,10 @@ void essentialBasicVarProcessor::Init(const InputCollections& input,VariableCont
     vars.InitVars( "Jet_GenJet_Pt","N_Jets" );
     vars.InitVars( "Jet_GenJet_Eta","N_Jets" );
     
-    vars.InitVars( "Jet_DeepCSV_b","N_Jets");
-    vars.InitVars( "Jet_DeepCSV_bb","N_Jets");
-    vars.InitVars( "Jet_DeepCSV_c","N_Jets");
-    vars.InitVars( "Jet_DeepCSV_udsg","N_Jets");
+    //vars.InitVars( "Jet_DeepCSV_b","N_Jets");
+    //vars.InitVars( "Jet_DeepCSV_bb","N_Jets");
+    //vars.InitVars( "Jet_DeepCSV_c","N_Jets");
+    //vars.InitVars( "Jet_DeepCSV_udsg","N_Jets");
 
     vars.InitVars( "Jet_DeepJetCSV","N_Jets");    
     vars.InitVars( "Jet_DeepJet_b","N_Jets");
@@ -90,25 +90,25 @@ void essentialBasicVarProcessor::Init(const InputCollections& input,VariableCont
     vars.InitVars( "Jet_DeepJet_uds","N_Jets");
     vars.InitVars( "Jet_DeepJet_g","N_Jets");
 
-    vars.InitVars( "TaggedJet_E","N_BTagsM" );
-    vars.InitVars( "TaggedJet_M","N_BTagsM" );
-    vars.InitVars( "TaggedJet_Pt","N_BTagsM" );
-    vars.InitVars( "TaggedJet_Phi","N_BTagsM" );
-    vars.InitVars( "TaggedJet_Eta","N_BTagsM" );
-    vars.InitVars( "TaggedJet_CSV","N_BTagsM" );
-    vars.InitVars( "TaggedJet_DeepJetCSV","N_BTagsM" );
-    vars.InitVars( "TaggedJet_DeepJet_b","N_BTagsM" );
-    vars.InitVars( "TaggedJet_DeepJet_bb","N_BTagsM" );
-    vars.InitVars( "TaggedJet_DeepJet_lepb","N_BTagsM" );
-    vars.InitVars( "TaggedJet_DeepJet_c","N_BTagsM" );
-    vars.InitVars( "TaggedJet_DeepJet_uds","N_BTagsM" );
-    vars.InitVars( "TaggedJet_DeepJet_g","N_BTagsM" );
+    //vars.InitVars( "TaggedJet_E","N_BTagsM" );
+    //vars.InitVars( "TaggedJet_M","N_BTagsM" );
+    //vars.InitVars( "TaggedJet_Pt","N_BTagsM" );
+    //vars.InitVars( "TaggedJet_Phi","N_BTagsM" );
+    //vars.InitVars( "TaggedJet_Eta","N_BTagsM" );
+    //vars.InitVars( "TaggedJet_CSV","N_BTagsM" );
+    //vars.InitVars( "TaggedJet_DeepJetCSV","N_BTagsM" );
+    //vars.InitVars( "TaggedJet_DeepJet_b","N_BTagsM" );
+    //vars.InitVars( "TaggedJet_DeepJet_bb","N_BTagsM" );
+    //vars.InitVars( "TaggedJet_DeepJet_lepb","N_BTagsM" );
+    //vars.InitVars( "TaggedJet_DeepJet_c","N_BTagsM" );
+    //vars.InitVars( "TaggedJet_DeepJet_uds","N_BTagsM" );
+    //vars.InitVars( "TaggedJet_DeepJet_g","N_BTagsM" );
 
-    vars.InitVars( "TightLepton_E","N_TightLeptons" );    
-    vars.InitVars( "TightLepton_M","N_TightLeptons" );    
-    vars.InitVars( "TightLepton_Pt","N_TightLeptons" );    
-    vars.InitVars( "TightLepton_Eta","N_TightLeptons" );    
-    vars.InitVars( "TightLepton_Phi","N_TightLeptons" );    
+    //vars.InitVars( "TightLepton_E","N_TightLeptons" );    
+    //vars.InitVars( "TightLepton_M","N_TightLeptons" );    
+    //vars.InitVars( "TightLepton_Pt","N_TightLeptons" );    
+    //vars.InitVars( "TightLepton_Eta","N_TightLeptons" );    
+    //vars.InitVars( "TightLepton_Phi","N_TightLeptons" );    
 
     vars.InitVars( "LooseLepton_E","N_LooseLeptons" );
     vars.InitVars( "LooseLepton_M","N_LooseLeptons" );
@@ -116,23 +116,23 @@ void essentialBasicVarProcessor::Init(const InputCollections& input,VariableCont
     vars.InitVars( "LooseLepton_Eta","N_LooseLeptons" );
     vars.InitVars( "LooseLepton_Phi","N_LooseLeptons" );
     
-    vars.InitVars( "LooseMuon_E","N_LooseMuons" );
-    vars.InitVars( "LooseMuon_M","N_LooseMuons" );
-    vars.InitVars( "LooseMuon_Pt","N_LooseMuons" );
-    vars.InitVars( "LooseMuon_Eta","N_LooseMuons" );
-    vars.InitVars( "LooseMuon_Phi","N_LooseMuons" );
-    vars.InitVars( "LooseMuon_RelIso","N_LooseMuons" );
-    vars.InitVars( "LooseMuon_Charge","N_LooseMuons" );
-    vars.InitVars( "LooseMuon_Pt_BeForeRC","N_LooseMuons" );
-    vars.InitVars( "LooseMuon_roccorSF", "N_LooseMuons");
-    vars.InitVars( "LooseMuon_roccorSFUp", "N_LooseMuons");
-    vars.InitVars( "LooseMuon_roccorSFDown", "N_LooseMuons");
-    vars.InitVars( "LooseMuon_IdentificationSF","N_LooseMuons");
-    vars.InitVars( "LooseMuon_IdentificationSFUp","N_LooseMuons");
-    vars.InitVars( "LooseMuon_IdentificationSFDown","N_LooseMuons");
-    vars.InitVars( "LooseMuon_IsolationSF","N_LooseMuons");
-    vars.InitVars( "LooseMuon_IsolationSFUp","N_LooseMuons");
-    vars.InitVars( "LooseMuon_IsolationSFDown","N_LooseMuons");
+    //vars.InitVars( "LooseMuon_E","N_LooseMuons" );
+    //vars.InitVars( "LooseMuon_M","N_LooseMuons" );
+    //vars.InitVars( "LooseMuon_Pt","N_LooseMuons" );
+    //vars.InitVars( "LooseMuon_Eta","N_LooseMuons" );
+    //vars.InitVars( "LooseMuon_Phi","N_LooseMuons" );
+    //vars.InitVars( "LooseMuon_RelIso","N_LooseMuons" );
+    //vars.InitVars( "LooseMuon_Charge","N_LooseMuons" );
+    //vars.InitVars( "LooseMuon_Pt_BeForeRC","N_LooseMuons" );
+    //vars.InitVars( "LooseMuon_roccorSF", "N_LooseMuons");
+    //vars.InitVars( "LooseMuon_roccorSFUp", "N_LooseMuons");
+    //vars.InitVars( "LooseMuon_roccorSFDown", "N_LooseMuons");
+    //vars.InitVars( "LooseMuon_IdentificationSF","N_LooseMuons");
+    //vars.InitVars( "LooseMuon_IdentificationSFUp","N_LooseMuons");
+    //vars.InitVars( "LooseMuon_IdentificationSFDown","N_LooseMuons");
+    //vars.InitVars( "LooseMuon_IsolationSF","N_LooseMuons");
+    //vars.InitVars( "LooseMuon_IsolationSFUp","N_LooseMuons");
+    //vars.InitVars( "LooseMuon_IsolationSFDown","N_LooseMuons");
 
     vars.InitVars( "Muon_E","N_TightMuons" );
     vars.InitVars( "Muon_M","N_TightMuons" );
@@ -154,27 +154,27 @@ void essentialBasicVarProcessor::Init(const InputCollections& input,VariableCont
 
 
     
-    vars.InitVars( "LooseElectron_E","N_LooseElectrons" );
-    vars.InitVars( "LooseElectron_M","N_LooseElectrons" );
-    vars.InitVars( "LooseElectron_Pt","N_LooseElectrons" );
-    vars.InitVars( "LooseElectron_Eta","N_LooseElectrons" );
-    vars.InitVars( "LooseElectron_Phi","N_LooseElectrons" );
-    vars.InitVars( "LooseElectron_RelIso","N_LooseElectrons" );
-    vars.InitVars( "LooseElectron_Charge","N_LooseElectrons" );
-    vars.InitVars( "LooseElectron_Pt_BeforeRun2Calibration","N_LooseElectrons" );
-    vars.InitVars( "LooseElectron_Eta_Supercluster","N_LooseElectrons" );
-    // electron energy scale combined up/down
-    vars.InitVars( "LooseElectron_CorrFactor_ScaleUp","N_LooseElectrons");
-    vars.InitVars( "LooseElectron_CorrFactor_ScaleDown","N_LooseElectrons");
-    // electron energy smearing combined up/down
-    vars.InitVars( "LooseElectron_CorrFactor_SigmaUp","N_LooseElectrons");
-    vars.InitVars( "LooseElectron_CorrFactor_SigmaDown","N_LooseElectrons");
-    vars.InitVars( "LooseElectron_IdentificationSF","N_LooseElectrons");
-    vars.InitVars( "LooseElectron_IdentificationSFUp","N_LooseElectrons");
-    vars.InitVars( "LooseElectron_IdentificationSFDown","N_LooseElectrons");
-    vars.InitVars( "LooseElectron_ReconstructionSF","N_LooseElectrons");
-    vars.InitVars( "LooseElectron_ReconstructionSFUp","N_LooseElectrons");
-    vars.InitVars( "LooseElectron_ReconstructionSFDown","N_LooseElectrons");
+    //vars.InitVars( "LooseElectron_E","N_LooseElectrons" );
+    //vars.InitVars( "LooseElectron_M","N_LooseElectrons" );
+    //vars.InitVars( "LooseElectron_Pt","N_LooseElectrons" );
+    //vars.InitVars( "LooseElectron_Eta","N_LooseElectrons" );
+    //vars.InitVars( "LooseElectron_Phi","N_LooseElectrons" );
+    //vars.InitVars( "LooseElectron_RelIso","N_LooseElectrons" );
+    //vars.InitVars( "LooseElectron_Charge","N_LooseElectrons" );
+    //vars.InitVars( "LooseElectron_Pt_BeforeRun2Calibration","N_LooseElectrons" );
+    //vars.InitVars( "LooseElectron_Eta_Supercluster","N_LooseElectrons" );
+    //// electron energy scale combined up/down
+    //vars.InitVars( "LooseElectron_CorrFactor_ScaleUp","N_LooseElectrons");
+    //vars.InitVars( "LooseElectron_CorrFactor_ScaleDown","N_LooseElectrons");
+    //// electron energy smearing combined up/down
+    //vars.InitVars( "LooseElectron_CorrFactor_SigmaUp","N_LooseElectrons");
+    //vars.InitVars( "LooseElectron_CorrFactor_SigmaDown","N_LooseElectrons");
+    //vars.InitVars( "LooseElectron_IdentificationSF","N_LooseElectrons");
+    //vars.InitVars( "LooseElectron_IdentificationSFUp","N_LooseElectrons");
+    //vars.InitVars( "LooseElectron_IdentificationSFDown","N_LooseElectrons");
+    //vars.InitVars( "LooseElectron_ReconstructionSF","N_LooseElectrons");
+    //vars.InitVars( "LooseElectron_ReconstructionSFUp","N_LooseElectrons");
+    //vars.InitVars( "LooseElectron_ReconstructionSFDown","N_LooseElectrons");
     
     vars.InitVars( "Electron_E","N_TightElectrons" );
     vars.InitVars( "Electron_M","N_TightElectrons" );
@@ -286,10 +286,10 @@ void essentialBasicVarProcessor::Process(const InputCollections& input,VariableC
             vars.FillVars( "Jet_GenJet_Eta",iJet,-9.0);
         }
 
-        vars.FillVars( "Jet_DeepCSV_b",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probb"));
-        vars.FillVars( "Jet_DeepCSV_bb",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probbb"));
-        vars.FillVars( "Jet_DeepCSV_c",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probc"));
-        vars.FillVars( "Jet_DeepCSV_udsg",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probudsg"));
+        //vars.FillVars( "Jet_DeepCSV_b",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probb"));
+        //vars.FillVars( "Jet_DeepCSV_bb",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probbb"));
+        //vars.FillVars( "Jet_DeepCSV_c",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probc"));
+        //vars.FillVars( "Jet_DeepCSV_udsg",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probudsg"));
         
         vars.FillVars( "Jet_DeepJetCSV",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"DeepJet"));
         vars.FillVars( "Jet_DeepJet_b",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probb"));
@@ -300,82 +300,82 @@ void essentialBasicVarProcessor::Process(const InputCollections& input,VariableC
         vars.FillVars( "Jet_DeepJet_g",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probg"));
     }
     
-    for(std::vector<pat::Jet>::const_iterator itJet = input.selectedJetsLoose.begin() ; itJet != input.selectedJetsLoose.end(); ++itJet)
-    {
-        int iJet = itJet - input.selectedJetsLoose.begin();
-        vars.FillVars( "LooseJet_E",iJet,itJet->energy() );
-        vars.FillVars( "LooseJet_M",iJet,itJet->mass() );
-        vars.FillVars( "LooseJet_Pt",iJet,itJet->pt() );
-        vars.FillVars( "LooseJet_Eta",iJet,itJet->eta() );
-        vars.FillVars( "LooseJet_Phi",iJet,itJet->phi() );
-        vars.FillVars( "LooseJet_CSV",iJet,CSVHelper::GetJetCSV(*itJet,btagger) );
-        //vars.FillVars( "LooseJet_CSV_DNN",iJet,CSVHelper::GetJetCSV_DNN(*itJet,btagger) );
-        vars.FillVars( "LooseJet_Flav",iJet,itJet->hadronFlavour() );
-        vars.FillVars( "LooseJet_PartonFlav",iJet,itJet->partonFlavour() );
-        vars.FillVars( "LooseJet_Charge",iJet,itJet->jetCharge() );
-        if(itJet->hasUserInt("pileupJetIdUpdated:fullId")) 
-            vars.FillVars( "LooseJet_PileUpID",iJet,itJet->userInt("pileupJetIdUpdated:fullId"));
-        if(itJet->hasUserFloat("pileupJetIdUpdated:fullDiscriminant")) 
-                vars.FillVars( "LooseJet_PileUpMVA",iJet,itJet->userFloat("pileupJetIdUpdated:fullDiscriminant"));
+    //for(std::vector<pat::Jet>::const_iterator itJet = input.selectedJetsLoose.begin() ; itJet != input.selectedJetsLoose.end(); ++itJet)
+    //{
+    //    int iJet = itJet - input.selectedJetsLoose.begin();
+    //    vars.FillVars( "LooseJet_E",iJet,itJet->energy() );
+    //    vars.FillVars( "LooseJet_M",iJet,itJet->mass() );
+    //    vars.FillVars( "LooseJet_Pt",iJet,itJet->pt() );
+    //    vars.FillVars( "LooseJet_Eta",iJet,itJet->eta() );
+    //    vars.FillVars( "LooseJet_Phi",iJet,itJet->phi() );
+    //    vars.FillVars( "LooseJet_CSV",iJet,CSVHelper::GetJetCSV(*itJet,btagger) );
+    //    //vars.FillVars( "LooseJet_CSV_DNN",iJet,CSVHelper::GetJetCSV_DNN(*itJet,btagger) );
+    //    vars.FillVars( "LooseJet_Flav",iJet,itJet->hadronFlavour() );
+    //    vars.FillVars( "LooseJet_PartonFlav",iJet,itJet->partonFlavour() );
+    //    vars.FillVars( "LooseJet_Charge",iJet,itJet->jetCharge() );
+    //    if(itJet->hasUserInt("pileupJetIdUpdated:fullId")) 
+    //        vars.FillVars( "LooseJet_PileUpID",iJet,itJet->userInt("pileupJetIdUpdated:fullId"));
+    //    if(itJet->hasUserFloat("pileupJetIdUpdated:fullDiscriminant")) 
+    //            vars.FillVars( "LooseJet_PileUpMVA",iJet,itJet->userFloat("pileupJetIdUpdated:fullDiscriminant"));
 
-        if(itJet->genJet()!=NULL)
-        {
-            vars.FillVars( "LooseJet_GenJet_Pt",iJet,itJet->genJet()->pt());
-            vars.FillVars( "LooseJet_GenJet_Eta",iJet,itJet->genJet()->eta());
-        }
-        else 
-        {
-            vars.FillVars( "LooseJet_GenJet_Pt",iJet,-9.0);
-            vars.FillVars( "LooseJet_GenJet_Eta",iJet,-9.0);
-        }
+    //    if(itJet->genJet()!=NULL)
+    //    {
+    //        vars.FillVars( "LooseJet_GenJet_Pt",iJet,itJet->genJet()->pt());
+    //        vars.FillVars( "LooseJet_GenJet_Eta",iJet,itJet->genJet()->eta());
+    //    }
+    //    else 
+    //    {
+    //        vars.FillVars( "LooseJet_GenJet_Pt",iJet,-9.0);
+    //        vars.FillVars( "LooseJet_GenJet_Eta",iJet,-9.0);
+    //    }
 
-        vars.FillVars( "LooseJet_DeepCSV_b",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probb"));
-        vars.FillVars( "LooseJet_DeepCSV_bb",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probbb"));
-        vars.FillVars( "LooseJet_DeepCSV_c",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probc"));
-        vars.FillVars( "LooseJet_DeepCSV_udsg",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probudsg"));
-        
-        vars.FillVars( "LooseJet_DeepJetCSV",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"DeepJet"));
-        vars.FillVars( "LooseJet_DeepJet_b",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probb"));
-        vars.FillVars( "LooseJet_DeepJet_bb",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probbb"));
-        vars.FillVars( "LooseJet_DeepJet_lepb",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:problepb"));
-        vars.FillVars( "LooseJet_DeepJet_c",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probc"));
-        vars.FillVars( "LooseJet_DeepJet_uds",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probuds"));
-        vars.FillVars( "LooseJet_DeepJet_g",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probg"));
-    }
+    //    vars.FillVars( "LooseJet_DeepCSV_b",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probb"));
+    //    vars.FillVars( "LooseJet_DeepCSV_bb",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probbb"));
+    //    vars.FillVars( "LooseJet_DeepCSV_c",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probc"));
+    //    vars.FillVars( "LooseJet_DeepCSV_udsg",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepCSVJetTags:probudsg"));
+    //    
+    //    vars.FillVars( "LooseJet_DeepJetCSV",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"DeepJet"));
+    //    vars.FillVars( "LooseJet_DeepJet_b",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probb"));
+    //    vars.FillVars( "LooseJet_DeepJet_bb",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probbb"));
+    //    vars.FillVars( "LooseJet_DeepJet_lepb",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:problepb"));
+    //    vars.FillVars( "LooseJet_DeepJet_c",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probc"));
+    //    vars.FillVars( "LooseJet_DeepJet_uds",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probuds"));
+    //    vars.FillVars( "LooseJet_DeepJet_g",iJet,CSVHelper::GetJetCSV_DNN(*itJet,"pfDeepFlavourJetTags:probg"));
+    //}
 
     
 
     
     // Tagged Jets
-    for(std::vector<pat::Jet>::iterator itTaggedJet = selectedTaggedJets.begin() ; itTaggedJet != selectedTaggedJets.end(); ++itTaggedJet)
-    {
-        int iTaggedJet = itTaggedJet - selectedTaggedJets.begin();
-        vars.FillVars( "TaggedJet_E",iTaggedJet,            itTaggedJet->energy() );
-        vars.FillVars( "TaggedJet_M",iTaggedJet,            itTaggedJet->mass() );
-        vars.FillVars( "TaggedJet_Pt",iTaggedJet,           itTaggedJet->pt() );
-        vars.FillVars( "TaggedJet_Eta",iTaggedJet,          itTaggedJet->eta() );
-        vars.FillVars( "TaggedJet_Phi",iTaggedJet,          itTaggedJet->phi() );
-        vars.FillVars( "TaggedJet_CSV",iTaggedJet,          CSVHelper::GetJetCSV(*itTaggedJet,btagger));
-        vars.FillVars( "TaggedJet_DeepJetCSV",iTaggedJet,   CSVHelper::GetJetCSV_DNN(*itTaggedJet,"DeepJet"));
-        vars.FillVars( "TaggedJet_DeepJet_b",iTaggedJet,    CSVHelper::GetJetCSV_DNN(*itTaggedJet,"pfDeepFlavourJetTags:probb"));
-        vars.FillVars( "TaggedJet_DeepJet_bb",iTaggedJet,   CSVHelper::GetJetCSV_DNN(*itTaggedJet,"pfDeepFlavourJetTags:probbb"));
-        vars.FillVars( "TaggedJet_DeepJet_lepb",iTaggedJet, CSVHelper::GetJetCSV_DNN(*itTaggedJet,"pfDeepFlavourJetTags:problepb"));
-        vars.FillVars( "TaggedJet_DeepJet_c",iTaggedJet,    CSVHelper::GetJetCSV_DNN(*itTaggedJet,"pfDeepFlavourJetTags:probc"));
-        vars.FillVars( "TaggedJet_DeepJet_uds",iTaggedJet,  CSVHelper::GetJetCSV_DNN(*itTaggedJet,"pfDeepFlavourJetTags:probuds"));
-        vars.FillVars( "TaggedJet_DeepJet_g",iTaggedJet,    CSVHelper::GetJetCSV_DNN(*itTaggedJet,"pfDeepFlavourJetTags:probg"));
-    }
+    //for(std::vector<pat::Jet>::iterator itTaggedJet = selectedTaggedJets.begin() ; itTaggedJet != selectedTaggedJets.end(); ++itTaggedJet)
+    //{
+    //    int iTaggedJet = itTaggedJet - selectedTaggedJets.begin();
+    //    vars.FillVars( "TaggedJet_E",iTaggedJet,            itTaggedJet->energy() );
+    //    vars.FillVars( "TaggedJet_M",iTaggedJet,            itTaggedJet->mass() );
+    //    vars.FillVars( "TaggedJet_Pt",iTaggedJet,           itTaggedJet->pt() );
+    //    vars.FillVars( "TaggedJet_Eta",iTaggedJet,          itTaggedJet->eta() );
+    //    vars.FillVars( "TaggedJet_Phi",iTaggedJet,          itTaggedJet->phi() );
+    //    vars.FillVars( "TaggedJet_CSV",iTaggedJet,          CSVHelper::GetJetCSV(*itTaggedJet,btagger));
+    //    vars.FillVars( "TaggedJet_DeepJetCSV",iTaggedJet,   CSVHelper::GetJetCSV_DNN(*itTaggedJet,"DeepJet"));
+    //    vars.FillVars( "TaggedJet_DeepJet_b",iTaggedJet,    CSVHelper::GetJetCSV_DNN(*itTaggedJet,"pfDeepFlavourJetTags:probb"));
+    //    vars.FillVars( "TaggedJet_DeepJet_bb",iTaggedJet,   CSVHelper::GetJetCSV_DNN(*itTaggedJet,"pfDeepFlavourJetTags:probbb"));
+    //    vars.FillVars( "TaggedJet_DeepJet_lepb",iTaggedJet, CSVHelper::GetJetCSV_DNN(*itTaggedJet,"pfDeepFlavourJetTags:problepb"));
+    //    vars.FillVars( "TaggedJet_DeepJet_c",iTaggedJet,    CSVHelper::GetJetCSV_DNN(*itTaggedJet,"pfDeepFlavourJetTags:probc"));
+    //    vars.FillVars( "TaggedJet_DeepJet_uds",iTaggedJet,  CSVHelper::GetJetCSV_DNN(*itTaggedJet,"pfDeepFlavourJetTags:probuds"));
+    //    vars.FillVars( "TaggedJet_DeepJet_g",iTaggedJet,    CSVHelper::GetJetCSV_DNN(*itTaggedJet,"pfDeepFlavourJetTags:probg"));
+    //}
 
     // Fill Lepton Variables
     std::vector<math::XYZTLorentzVector> tightLeptonVecs = BoostedUtils::GetLepVecs(input.selectedElectrons,input.selectedMuons);
-    for(auto itLep = tightLeptonVecs.begin(); itLep != tightLeptonVecs.end(); ++itLep)
-    {
-        int iLep = itLep - tightLeptonVecs.begin();
-        vars.FillVars( "TightLepton_E",iLep,itLep->E() );
-        vars.FillVars( "TightLepton_M",iLep,itLep->M() );
-        vars.FillVars( "TightLepton_Pt",iLep,itLep->Pt() );
-        vars.FillVars( "TightLepton_Eta",iLep,itLep->Eta());
-        vars.FillVars( "TightLepton_Phi",iLep,itLep->Phi() );
-    }
+    //for(auto itLep = tightLeptonVecs.begin(); itLep != tightLeptonVecs.end(); ++itLep)
+    //{
+    //    int iLep = itLep - tightLeptonVecs.begin();
+    //    vars.FillVars( "TightLepton_E",iLep,itLep->E() );
+    //    vars.FillVars( "TightLepton_M",iLep,itLep->M() );
+    //    vars.FillVars( "TightLepton_Pt",iLep,itLep->Pt() );
+    //    vars.FillVars( "TightLepton_Eta",iLep,itLep->Eta());
+    //    vars.FillVars( "TightLepton_Phi",iLep,itLep->Phi() );
+    //}
     std::vector<math::XYZTLorentzVector> looseLeptonVecs = BoostedUtils::GetLepVecs(input.selectedElectronsLoose,input.selectedMuonsLoose);
     for(std::vector<math::XYZTLorentzVector>::iterator itLep = looseLeptonVecs.begin() ; itLep != looseLeptonVecs.end(); ++itLep)
     {
@@ -387,41 +387,41 @@ void essentialBasicVarProcessor::Process(const InputCollections& input,VariableC
         vars.FillVars( "LooseLepton_Phi",iLep,itLep->Phi() );
     }
      
-    for(std::vector<pat::Electron>::const_iterator itEle = input.selectedElectronsLoose.begin(); itEle != input.selectedElectronsLoose.end(); ++itEle)
-    {
-        int iEle = itEle - input.selectedElectronsLoose.begin();
-        vars.FillVars( "LooseElectron_E",iEle,itEle->energy() );
-        vars.FillVars( "LooseElectron_M",iEle,itEle->mass() );
-        vars.FillVars( "LooseElectron_Pt",iEle,itEle->pt() );
-        vars.FillVars( "LooseElectron_Eta",iEle,itEle->eta() );
-        vars.FillVars( "LooseElectron_Phi",iEle,itEle->phi() ); 
-        if(itEle->hasUserFloat("relIso"))
-            vars.FillVars( "LooseElectron_RelIso",iEle,itEle->userFloat("relIso") );
+    //for(std::vector<pat::Electron>::const_iterator itEle = input.selectedElectronsLoose.begin(); itEle != input.selectedElectronsLoose.end(); ++itEle)
+    //{
+    //    int iEle = itEle - input.selectedElectronsLoose.begin();
+    //    vars.FillVars( "LooseElectron_E",iEle,itEle->energy() );
+    //    vars.FillVars( "LooseElectron_M",iEle,itEle->mass() );
+    //    vars.FillVars( "LooseElectron_Pt",iEle,itEle->pt() );
+    //    vars.FillVars( "LooseElectron_Eta",iEle,itEle->eta() );
+    //    vars.FillVars( "LooseElectron_Phi",iEle,itEle->phi() ); 
+    //    if(itEle->hasUserFloat("relIso"))
+    //        vars.FillVars( "LooseElectron_RelIso",iEle,itEle->userFloat("relIso") );
 
-        vars.FillVars( "LooseElectron_Charge",iEle,itEle->charge() ); 
-        if(itEle->hasUserFloat("ptBeforeRun2Calibration"))
-            vars.FillVars("LooseElectron_Pt_BeforeRun2Calibration",iEle,itEle->userFloat("ptBeforeRun2Calibration"));
+    //    vars.FillVars( "LooseElectron_Charge",iEle,itEle->charge() ); 
+    //    if(itEle->hasUserFloat("ptBeforeRun2Calibration"))
+    //        vars.FillVars("LooseElectron_Pt_BeforeRun2Calibration",iEle,itEle->userFloat("ptBeforeRun2Calibration"));
 
-        vars.FillVars("LooseElectron_Eta_Supercluster",iEle,itEle->superCluster()->eta());
-        if(itEle->hasUserFloat("CorrFactor_ScaleUp"))
-        {
-            // electron energy scale combined up/down
-            vars.FillVars( "LooseElectron_CorrFactor_ScaleUp",iEle,itEle->userFloat("CorrFactor_ScaleUp"));
-            vars.FillVars( "LooseElectron_CorrFactor_ScaleDown",iEle,itEle->userFloat("CorrFactor_ScaleDown"));
-            // electron energy smearing combined up/down
-            vars.FillVars( "LooseElectron_CorrFactor_SigmaUp",iEle,itEle->userFloat("CorrFactor_SigmaUp"));
-            vars.FillVars( "LooseElectron_CorrFactor_SigmaDown",iEle,itEle->userFloat("CorrFactor_SigmaDown"));
-        }
-        if(itEle->hasUserFloat("IdentificationSF")) 
-        {
-            vars.FillVars( "LooseElectron_IdentificationSF",iEle,itEle->userFloat("IdentificationSF"));
-            vars.FillVars( "LooseElectron_IdentificationSFUp",iEle,itEle->userFloat("IdentificationSFUp"));
-            vars.FillVars( "LooseElectron_IdentificationSFDown",iEle,itEle->userFloat("IdentificationSFDown"));
-            vars.FillVars( "LooseElectron_ReconstructionSF",iEle,itEle->userFloat("ReconstructionSF"));
-            vars.FillVars( "LooseElectron_ReconstructionSFUp",iEle,itEle->userFloat("ReconstructionSFUp"));
-            vars.FillVars( "LooseElectron_ReconstructionSFDown",iEle,itEle->userFloat("ReconstructionSFDown"));
-        }
-    }
+    //    vars.FillVars("LooseElectron_Eta_Supercluster",iEle,itEle->superCluster()->eta());
+    //    if(itEle->hasUserFloat("CorrFactor_ScaleUp"))
+    //    {
+    //        // electron energy scale combined up/down
+    //        vars.FillVars( "LooseElectron_CorrFactor_ScaleUp",iEle,itEle->userFloat("CorrFactor_ScaleUp"));
+    //        vars.FillVars( "LooseElectron_CorrFactor_ScaleDown",iEle,itEle->userFloat("CorrFactor_ScaleDown"));
+    //        // electron energy smearing combined up/down
+    //        vars.FillVars( "LooseElectron_CorrFactor_SigmaUp",iEle,itEle->userFloat("CorrFactor_SigmaUp"));
+    //        vars.FillVars( "LooseElectron_CorrFactor_SigmaDown",iEle,itEle->userFloat("CorrFactor_SigmaDown"));
+    //    }
+    //    if(itEle->hasUserFloat("IdentificationSF")) 
+    //    {
+    //        vars.FillVars( "LooseElectron_IdentificationSF",iEle,itEle->userFloat("IdentificationSF"));
+    //        vars.FillVars( "LooseElectron_IdentificationSFUp",iEle,itEle->userFloat("IdentificationSFUp"));
+    //        vars.FillVars( "LooseElectron_IdentificationSFDown",iEle,itEle->userFloat("IdentificationSFDown"));
+    //        vars.FillVars( "LooseElectron_ReconstructionSF",iEle,itEle->userFloat("ReconstructionSF"));
+    //        vars.FillVars( "LooseElectron_ReconstructionSFUp",iEle,itEle->userFloat("ReconstructionSFUp"));
+    //        vars.FillVars( "LooseElectron_ReconstructionSFDown",iEle,itEle->userFloat("ReconstructionSFDown"));
+    //    }
+    //}
     for(std::vector<pat::Electron>::const_iterator itEle = input.selectedElectrons.begin(); itEle != input.selectedElectrons.end(); ++itEle)
     {
         int iEle = itEle - input.selectedElectrons.begin();
@@ -458,43 +458,43 @@ void essentialBasicVarProcessor::Process(const InputCollections& input,VariableC
         }
     }
     
-    for(std::vector<pat::Muon>::const_iterator itMu = input.selectedMuonsLoose.begin(); itMu != input.selectedMuonsLoose.end(); ++itMu)
-    {
-        int iMu = itMu - input.selectedMuonsLoose.begin();
-        vars.FillVars( "LooseMuon_E",iMu,itMu->energy() );
-        vars.FillVars( "LooseMuon_M",iMu,itMu->mass() );
-        vars.FillVars( "LooseMuon_Pt",iMu,itMu->pt() );
-        vars.FillVars( "LooseMuon_Eta",iMu,itMu->eta() );
-        vars.FillVars( "LooseMuon_Phi",iMu,itMu->phi() );
-        if(itMu->hasUserFloat("relIso"))
-            vars.FillVars( "LooseMuon_RelIso",iMu,itMu->userFloat("relIso") );
+    //for(std::vector<pat::Muon>::const_iterator itMu = input.selectedMuonsLoose.begin(); itMu != input.selectedMuonsLoose.end(); ++itMu)
+    //{
+    //    int iMu = itMu - input.selectedMuonsLoose.begin();
+    //    vars.FillVars( "LooseMuon_E",iMu,itMu->energy() );
+    //    vars.FillVars( "LooseMuon_M",iMu,itMu->mass() );
+    //    vars.FillVars( "LooseMuon_Pt",iMu,itMu->pt() );
+    //    vars.FillVars( "LooseMuon_Eta",iMu,itMu->eta() );
+    //    vars.FillVars( "LooseMuon_Phi",iMu,itMu->phi() );
+    //    if(itMu->hasUserFloat("relIso"))
+    //        vars.FillVars( "LooseMuon_RelIso",iMu,itMu->userFloat("relIso") );
 
-        vars.FillVars( "LooseMuon_Charge",iMu,itMu->charge() );
-        if(itMu->hasUserFloat("PtbeforeRC"))
-            vars.FillVars( "LooseMuon_Pt_BeForeRC",iMu,itMu->userFloat("PtbeforeRC") );
+    //    vars.FillVars( "LooseMuon_Charge",iMu,itMu->charge() );
+    //    if(itMu->hasUserFloat("PtbeforeRC"))
+    //        vars.FillVars( "LooseMuon_Pt_BeForeRC",iMu,itMu->userFloat("PtbeforeRC") );
 
-        if(itMu->hasUserFloat("roccorSF"))
-            vars.FillVars( "LooseMuon_roccorSF",iMu,itMu->userFloat("roccorSF") );
+    //    if(itMu->hasUserFloat("roccorSF"))
+    //        vars.FillVars( "LooseMuon_roccorSF",iMu,itMu->userFloat("roccorSF") );
 
-        if(itMu->hasUserFloat("roccorSFUp"))
-            vars.FillVars( "LooseMuon_roccorSFUp",iMu,itMu->userFloat("roccorSFUp") );
+    //    if(itMu->hasUserFloat("roccorSFUp"))
+    //        vars.FillVars( "LooseMuon_roccorSFUp",iMu,itMu->userFloat("roccorSFUp") );
 
-        if(itMu->hasUserFloat("roccorSFDown"))
-            vars.FillVars( "LooseMuon_roccorSFDown",iMu,itMu->userFloat("roccorSFDown") );
+    //    if(itMu->hasUserFloat("roccorSFDown"))
+    //        vars.FillVars( "LooseMuon_roccorSFDown",iMu,itMu->userFloat("roccorSFDown") );
 
-        if(itMu->hasUserFloat("IdentificationSF"))
-        {
-            vars.FillVars( "LooseMuon_IdentificationSF",iMu,itMu->userFloat("IdentificationSF"));
-            vars.FillVars( "LooseMuon_IdentificationSFUp",iMu,itMu->userFloat("IdentificationSFUp"));
-            vars.FillVars( "LooseMuon_IdentificationSFDown",iMu,itMu->userFloat("IdentificationSFDown"));
-        }
-        if(itMu->hasUserFloat("IsolationSF"))
-        {
-            vars.FillVars( "LooseMuon_IsolationSF",iMu,itMu->userFloat("IsolationSF"));
-            vars.FillVars( "LooseMuon_IsolationSFUp",iMu,itMu->userFloat("IsolationSFUp"));
-            vars.FillVars( "LooseMuon_IsolationSFDown",iMu,itMu->userFloat("IsolationSFDown"));
-        }
-    }
+    //    if(itMu->hasUserFloat("IdentificationSF"))
+    //    {
+    //        vars.FillVars( "LooseMuon_IdentificationSF",iMu,itMu->userFloat("IdentificationSF"));
+    //        vars.FillVars( "LooseMuon_IdentificationSFUp",iMu,itMu->userFloat("IdentificationSFUp"));
+    //        vars.FillVars( "LooseMuon_IdentificationSFDown",iMu,itMu->userFloat("IdentificationSFDown"));
+    //    }
+    //    if(itMu->hasUserFloat("IsolationSF"))
+    //    {
+    //        vars.FillVars( "LooseMuon_IsolationSF",iMu,itMu->userFloat("IsolationSF"));
+    //        vars.FillVars( "LooseMuon_IsolationSFUp",iMu,itMu->userFloat("IsolationSFUp"));
+    //        vars.FillVars( "LooseMuon_IsolationSFDown",iMu,itMu->userFloat("IsolationSFDown"));
+    //    }
+    //}
     for(std::vector<pat::Muon>::const_iterator itMu = input.selectedMuons.begin(); itMu != input.selectedMuons.end(); ++itMu)
     {
         int iMu = itMu - input.selectedMuons.begin();

--- a/BoostedAnalyzer/src/essentialRecoVarProcessor.cpp
+++ b/BoostedAnalyzer/src/essentialRecoVarProcessor.cpp
@@ -4,7 +4,8 @@ using namespace std;
 
 essentialRecoVarProcessor::essentialRecoVarProcessor()
 {
-    // reconstruct ttH, reconstruct ttZ
+    // ReconstructedVars(bool ttH, bool ttZ)
+    // arguments activate chi2based ttH and ttZ reconstruction
     pointerToRecoVars.reset(new ReconstructedVars(true, false));
 }
 

--- a/BoostedAnalyzer/src/essentialRecoVarProcessor.cpp
+++ b/BoostedAnalyzer/src/essentialRecoVarProcessor.cpp
@@ -5,7 +5,7 @@ using namespace std;
 essentialRecoVarProcessor::essentialRecoVarProcessor()
 {
     // reconstruct ttH, reconstruct ttZ
-    pointerToRecoVars.reset(new ReconstructedVars(true, true));
+    pointerToRecoVars.reset(new ReconstructedVars(true, false));
 }
 
 essentialRecoVarProcessor::~essentialRecoVarProcessor() {}

--- a/BoostedAnalyzer/src/essentialRecoVarProcessor.cpp
+++ b/BoostedAnalyzer/src/essentialRecoVarProcessor.cpp
@@ -4,7 +4,8 @@ using namespace std;
 
 essentialRecoVarProcessor::essentialRecoVarProcessor()
 {
-    pointerToRecoVars.reset(new ReconstructedVars());
+    // reconstruct ttH, reconstruct ttZ
+    pointerToRecoVars.reset(new ReconstructedVars(true, true));
 }
 
 essentialRecoVarProcessor::~essentialRecoVarProcessor() {}

--- a/BoostedAnalyzer/test/boostedAnalysis_ntuples-Legacy_2016_2017_2018_cfg.py
+++ b/BoostedAnalyzer/test/boostedAnalysis_ntuples-Legacy_2016_2017_2018_cfg.py
@@ -73,7 +73,24 @@ if not options.inputFiles:
             options.inputFiles=['file:///pnfs/desy.de/cms/tier2/store/user/mwassmer/TTToSemiLeptonic_TuneCP5_PSweights_13TeV-powheg-pythia8/KIT_tthbb_sl_skims_MC_v2_94X/181109_144129/0000/Skim_1.root']
         elif "2018" in options.dataEra:
             # options.inputFiles=['root://xrootd-cms.infn.it//store/mc/RunIIAutumn18MiniAOD/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/102X_upgrade2018_realistic_v15-v1/40000/EAA9C941-768D-164B-B5C1-C12306823C6E.root']
-        	options.inputFiles=['file:///pnfs/desy.de/cms/tier2/store/user/mschrode/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/KIT_tthbb_skims_MC_94X_LEG_2018/190406_083857/0000/Skim_7.root']
+            #options.inputFiles=[
+            #    'file:///pnfs/desy.de/cms/tier2/store/user/mschrode/ttHTobb_M125_TuneCP5_13TeV-powheg-pythia8/KIT_tthbb_skims_MC_94X_LEG_2018_v2/190412_134753/0000/Skim_1.root',
+            #    'file:///pnfs/desy.de/cms/tier2/store/user/mschrode/ttHTobb_M125_TuneCP5_13TeV-powheg-pythia8/KIT_tthbb_skims_MC_94X_LEG_2018_v2/190412_134753/0000/Skim_2.root',
+            #    'file:///pnfs/desy.de/cms/tier2/store/user/mschrode/ttHTobb_M125_TuneCP5_13TeV-powheg-pythia8/KIT_tthbb_skims_MC_94X_LEG_2018_v2/190412_134753/0000/Skim_3.root',
+            #    'file:///pnfs/desy.de/cms/tier2/store/user/mschrode/ttHTobb_M125_TuneCP5_13TeV-powheg-pythia8/KIT_tthbb_skims_MC_94X_LEG_2018_v2/190412_134753/0000/Skim_4.root',
+            #    'file:///pnfs/desy.de/cms/tier2/store/user/mschrode/ttHTobb_M125_TuneCP5_13TeV-powheg-pythia8/KIT_tthbb_skims_MC_94X_LEG_2018_v2/190412_134753/0000/Skim_5.root']
+            #options.inputFiles=[
+            #    'file:///pnfs/desy.de/cms/tier2/store/user/mschrode/TTZToBB_TuneCP5_13TeV-amcatnlo-pythia8/KIT_tthbb_skims_MC_94X_LEG_2018_v2/190412_135752/0000/Skim_1.root',
+            #    'file:///pnfs/desy.de/cms/tier2/store/user/mschrode/TTZToBB_TuneCP5_13TeV-amcatnlo-pythia8/KIT_tthbb_skims_MC_94X_LEG_2018_v2/190412_135752/0000/Skim_2.root',
+            #    'file:///pnfs/desy.de/cms/tier2/store/user/mschrode/TTZToBB_TuneCP5_13TeV-amcatnlo-pythia8/KIT_tthbb_skims_MC_94X_LEG_2018_v2/190412_135752/0000/Skim_3.root',
+            #    'file:///pnfs/desy.de/cms/tier2/store/user/mschrode/TTZToBB_TuneCP5_13TeV-amcatnlo-pythia8/KIT_tthbb_skims_MC_94X_LEG_2018_v2/190412_135752/0000/Skim_4.root',
+            #    'file:///pnfs/desy.de/cms/tier2/store/user/mschrode/TTZToBB_TuneCP5_13TeV-amcatnlo-pythia8/KIT_tthbb_skims_MC_94X_LEG_2018_v2/190412_135752/0000/Skim_5.root']
+            options.inputFiles=[
+                'file:///pnfs/desy.de/cms/tier2/store/user/mschrode/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/KIT_tthbb_skims_MC_94X_LEG_2018/190406_083857/0000/Skim_1.root',
+                'file:///pnfs/desy.de/cms/tier2/store/user/mschrode/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/KIT_tthbb_skims_MC_94X_LEG_2018/190406_083857/0000/Skim_2.root',
+                'file:///pnfs/desy.de/cms/tier2/store/user/mschrode/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/KIT_tthbb_skims_MC_94X_LEG_2018/190406_083857/0000/Skim_3.root',
+                'file:///pnfs/desy.de/cms/tier2/store/user/mschrode/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/KIT_tthbb_skims_MC_94X_LEG_2018/190406_083857/0000/Skim_4.root',
+                'file:///pnfs/desy.de/cms/tier2/store/user/mschrode/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/KIT_tthbb_skims_MC_94X_LEG_2018/190406_083857/0000/Skim_5.root']
     else:
         if "2016" in options.dataEra: # CAREFUL: NO 2016 Data Skims ready yet
             # options.inputFiles=['file:///pnfs/desy.de/cms/tier2/store/user/swieland/TTToSemilepton_TuneCUETP8M2_ttHtranche3_13TeV-powheg-pythia8/KIT_tthbb_skims_MC_94X_LEG_2016/190328_111449/0000/Skim_1.root']
@@ -640,7 +657,6 @@ if options.isData:
 else:
   process.BoostedAnalyzer.processorNames=cms.vstring(
   "WeightProcessor",
-#  "MCMatchVarProcessor",
   "MCMatchVarProcessor",
   "essentialBasicVarProcessor",
   "essentialMVAVarProcessor",

--- a/BoostedAnalyzer/test/boostedAnalysis_ntuples-Legacy_2016_2017_2018_cfg.py
+++ b/BoostedAnalyzer/test/boostedAnalysis_ntuples-Legacy_2016_2017_2018_cfg.py
@@ -72,25 +72,12 @@ if not options.inputFiles:
         elif "2017" in options.dataEra: 
             options.inputFiles=['file:///pnfs/desy.de/cms/tier2/store/user/mwassmer/TTToSemiLeptonic_TuneCP5_PSweights_13TeV-powheg-pythia8/KIT_tthbb_sl_skims_MC_v2_94X/181109_144129/0000/Skim_1.root']
         elif "2018" in options.dataEra:
-            # options.inputFiles=['root://xrootd-cms.infn.it//store/mc/RunIIAutumn18MiniAOD/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/102X_upgrade2018_realistic_v15-v1/40000/EAA9C941-768D-164B-B5C1-C12306823C6E.root']
             #options.inputFiles=[
-            #    'file:///pnfs/desy.de/cms/tier2/store/user/mschrode/ttHTobb_M125_TuneCP5_13TeV-powheg-pythia8/KIT_tthbb_skims_MC_94X_LEG_2018_v2/190412_134753/0000/Skim_1.root',
-            #    'file:///pnfs/desy.de/cms/tier2/store/user/mschrode/ttHTobb_M125_TuneCP5_13TeV-powheg-pythia8/KIT_tthbb_skims_MC_94X_LEG_2018_v2/190412_134753/0000/Skim_2.root',
-            #    'file:///pnfs/desy.de/cms/tier2/store/user/mschrode/ttHTobb_M125_TuneCP5_13TeV-powheg-pythia8/KIT_tthbb_skims_MC_94X_LEG_2018_v2/190412_134753/0000/Skim_3.root',
-            #    'file:///pnfs/desy.de/cms/tier2/store/user/mschrode/ttHTobb_M125_TuneCP5_13TeV-powheg-pythia8/KIT_tthbb_skims_MC_94X_LEG_2018_v2/190412_134753/0000/Skim_4.root',
-            #    'file:///pnfs/desy.de/cms/tier2/store/user/mschrode/ttHTobb_M125_TuneCP5_13TeV-powheg-pythia8/KIT_tthbb_skims_MC_94X_LEG_2018_v2/190412_134753/0000/Skim_5.root']
+            #    'file:///pnfs/desy.de/cms/tier2/store/user/mschrode/ttHTobb_M125_TuneCP5_13TeV-powheg-pythia8/KIT_tthbb_skims_MC_94X_LEG_2018_v2/190412_134753/0000/Skim_1.root']
             #options.inputFiles=[
-            #    'file:///pnfs/desy.de/cms/tier2/store/user/mschrode/TTZToBB_TuneCP5_13TeV-amcatnlo-pythia8/KIT_tthbb_skims_MC_94X_LEG_2018_v2/190412_135752/0000/Skim_1.root',
-            #    'file:///pnfs/desy.de/cms/tier2/store/user/mschrode/TTZToBB_TuneCP5_13TeV-amcatnlo-pythia8/KIT_tthbb_skims_MC_94X_LEG_2018_v2/190412_135752/0000/Skim_2.root',
-            #    'file:///pnfs/desy.de/cms/tier2/store/user/mschrode/TTZToBB_TuneCP5_13TeV-amcatnlo-pythia8/KIT_tthbb_skims_MC_94X_LEG_2018_v2/190412_135752/0000/Skim_3.root',
-            #    'file:///pnfs/desy.de/cms/tier2/store/user/mschrode/TTZToBB_TuneCP5_13TeV-amcatnlo-pythia8/KIT_tthbb_skims_MC_94X_LEG_2018_v2/190412_135752/0000/Skim_4.root',
-            #    'file:///pnfs/desy.de/cms/tier2/store/user/mschrode/TTZToBB_TuneCP5_13TeV-amcatnlo-pythia8/KIT_tthbb_skims_MC_94X_LEG_2018_v2/190412_135752/0000/Skim_5.root']
+            #    'file:///pnfs/desy.de/cms/tier2/store/user/mschrode/TTZToBB_TuneCP5_13TeV-amcatnlo-pythia8/KIT_tthbb_skims_MC_94X_LEG_2018_v2/190412_135752/0000/Skim_1.root']
             options.inputFiles=[
-                'file:///pnfs/desy.de/cms/tier2/store/user/mschrode/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/KIT_tthbb_skims_MC_94X_LEG_2018/190406_083857/0000/Skim_1.root',
-                'file:///pnfs/desy.de/cms/tier2/store/user/mschrode/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/KIT_tthbb_skims_MC_94X_LEG_2018/190406_083857/0000/Skim_2.root',
-                'file:///pnfs/desy.de/cms/tier2/store/user/mschrode/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/KIT_tthbb_skims_MC_94X_LEG_2018/190406_083857/0000/Skim_3.root',
-                'file:///pnfs/desy.de/cms/tier2/store/user/mschrode/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/KIT_tthbb_skims_MC_94X_LEG_2018/190406_083857/0000/Skim_4.root',
-                'file:///pnfs/desy.de/cms/tier2/store/user/mschrode/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/KIT_tthbb_skims_MC_94X_LEG_2018/190406_083857/0000/Skim_5.root']
+                'file:///pnfs/desy.de/cms/tier2/store/user/mschrode/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/KIT_tthbb_skims_MC_94X_LEG_2018/190406_083857/0000/Skim_1.root']
     else:
         if "2016" in options.dataEra: # CAREFUL: NO 2016 Data Skims ready yet
             # options.inputFiles=['file:///pnfs/desy.de/cms/tier2/store/user/swieland/TTToSemilepton_TuneCUETP8M2_ttHtranche3_13TeV-powheg-pythia8/KIT_tthbb_skims_MC_94X_LEG_2016/190328_111449/0000/Skim_1.root']

--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ Do for example:
     cd TTH
     if [[ $CMSSW_VERSION == "CMSSW_10_2_"* ]]; then
       # git clone https://git@gitlab.cern.ch/algomez/CommonClassifier.git CommonClassifier -b 10_2_X
-      git clone https://gitlab.cern.ch/swieland/CommonClassifier.git CommonClassifier -b 10_2X_ttZReconstruction
+      git clone https://gitlab.cern.ch/swieland/CommonClassifier.git CommonClassifier -b 10_2X_MVAvars
       git clone https://gitlab.cern.ch/algomez/MEIntegratorStandalone.git MEIntegratorStandalone -b 10_2_X
     elif [[ $CMSSW_VERSION == "CMSSW_9_4_"* ]]; then
       # git clone https://git@gitlab.cern.ch/algomez/CommonClassifier.git CommonClassifier
-      git clone https://gitlab.cern.ch/swieland/CommonClassifier.git CommonClassifier -b 10_2X_ttZReconstruction
+      git clone https://gitlab.cern.ch/swieland/CommonClassifier.git CommonClassifier -b 10_2X_MVAvars
       git clone https://gitlab.cern.ch/algomez/MEIntegratorStandalone.git MEIntegratorStandalone
     else
       echo "WRONG CMSSW VERSION"

--- a/README.md
+++ b/README.md
@@ -59,17 +59,16 @@ Do for example:
     cd TTH
     if [[ $CMSSW_VERSION == "CMSSW_10_2_"* ]]; then
       # git clone https://git@gitlab.cern.ch/algomez/CommonClassifier.git CommonClassifier -b 10_2_X
-      git clone https://gitlab.cern.ch/swieland/CommonClassifier.git CommonClassifier -b 10_2X_MVAvars
+      git clone https://gitlab.cern.ch/swieland/CommonClassifier.git CommonClassifier -b 10_2X_ttZReconstruction
       git clone https://gitlab.cern.ch/algomez/MEIntegratorStandalone.git MEIntegratorStandalone -b 10_2_X
     elif [[ $CMSSW_VERSION == "CMSSW_9_4_"* ]]; then
       # git clone https://git@gitlab.cern.ch/algomez/CommonClassifier.git CommonClassifier
-      git clone https://gitlab.cern.ch/swieland/CommonClassifier.git CommonClassifier -b 10_2X_MVAvars
+      git clone https://gitlab.cern.ch/swieland/CommonClassifier.git CommonClassifier -b 10_2X_ttZReconstruction
       git clone https://gitlab.cern.ch/algomez/MEIntegratorStandalone.git MEIntegratorStandalone
     else
       echo "WRONG CMSSW VERSION"
       return 1
     fi
-    git clone https://gitlab.cern.ch/kit-cn-cms-public/RecoLikelihoodReconstruction.git RecoLikelihoodReconstruction
     mkdir -p $CMSSW_BASE/lib/$SCRAM_ARCH/
     cp -R MEIntegratorStandalone/libs/* $CMSSW_BASE/lib/$SCRAM_ARCH/
     scram setup lhapdf


### PR DESCRIPTION
- adjusted calls of Chi2 reconstruction to match structure in CommonClassifier. With these settings only ttH will be reconstructed, ttZ is deactivated.
- added a script in `boostedAnalyzer/scripts/` to calculate dR matching efficiencies on a ntuple file
- added code to read out generator level Z boson information (currenty deactivated)
- added code to generate mass templates for Chi2 reconstructions
- added code to generate `ttH/ttbar_matched` flags for efficiency calculations of various reconstruction methods (currently deactivated)